### PR TITLE
feat(action): implement PlayCard and PlaySpecialAction command handlers, closes #28

### DIFF
--- a/src/main/java/io/github/temporalrift/game/action/application/command/PlayCardCommandHandler.java
+++ b/src/main/java/io/github/temporalrift/game/action/application/command/PlayCardCommandHandler.java
@@ -1,0 +1,55 @@
+package io.github.temporalrift.game.action.application.command;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.github.temporalrift.game.action.application.port.in.PlayCardUseCase;
+import io.github.temporalrift.game.action.domain.actionround.RoundNotFoundException;
+import io.github.temporalrift.game.action.domain.playerstate.PlayerState;
+import io.github.temporalrift.game.action.domain.playerstate.PlayerStateNotFoundException;
+import io.github.temporalrift.game.action.domain.port.out.ActionRoundRepository;
+import io.github.temporalrift.game.action.domain.port.out.PlayerStateRepository;
+
+@Service
+class PlayCardCommandHandler implements PlayCardUseCase {
+
+    private final ActionRoundRepository actionRoundRepository;
+
+    private final PlayerStateRepository playerStateRepository;
+
+    PlayCardCommandHandler(ActionRoundRepository actionRoundRepository, PlayerStateRepository playerStateRepository) {
+        this.actionRoundRepository = actionRoundRepository;
+        this.playerStateRepository = playerStateRepository;
+    }
+
+    @Override
+    @Transactional
+    public Result handle(Command command) {
+        var round = actionRoundRepository
+                .findByGameIdAndEraNumberAndRoundNumber(command.gameId(), command.eraNumber(), command.roundNumber())
+                .orElseThrow(
+                        () -> new RoundNotFoundException(command.gameId(), command.eraNumber(), command.roundNumber()));
+        var playerState = playerStateRepository
+                .findByGameIdAndPlayerId(command.gameId(), command.playerId())
+                .orElseThrow(() -> new PlayerStateNotFoundException(command.gameId(), command.playerId()));
+        var playerHand = playerState.hand().stream()
+                .map(PlayerState.CardInstance::cardInstanceId)
+                .toList();
+        var allSubmitted = round.submitCard(
+                command.playerId(),
+                command.cardInstanceId(),
+                command.cardType(),
+                command.targetEventId(),
+                command.targetOutcomeId(),
+                playerHand);
+        playerState.removeCard(command.cardInstanceId());
+        if (allSubmitted) {
+            round.close("ALL_SUBMITTED");
+        }
+        actionRoundRepository.save(round);
+        playerStateRepository.save(playerState);
+
+        return new Result(
+                command.gameId(), command.eraNumber(), command.roundNumber(), command.playerId(), allSubmitted);
+    }
+}

--- a/src/main/java/io/github/temporalrift/game/action/application/command/PlayCardCommandHandler.java
+++ b/src/main/java/io/github/temporalrift/game/action/application/command/PlayCardCommandHandler.java
@@ -1,5 +1,6 @@
 package io.github.temporalrift.game.action.application.command;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,6 +12,7 @@ import io.github.temporalrift.game.action.domain.port.out.ActionRoundRepository;
 import io.github.temporalrift.game.action.domain.port.out.PlayerStateRepository;
 
 @Service
+@ConditionalOnBean({ActionRoundRepository.class, PlayerStateRepository.class})
 class PlayCardCommandHandler implements PlayCardUseCase {
 
     private final ActionRoundRepository actionRoundRepository;

--- a/src/main/java/io/github/temporalrift/game/action/application/command/PlaySpecialActionCommandHandler.java
+++ b/src/main/java/io/github/temporalrift/game/action/application/command/PlaySpecialActionCommandHandler.java
@@ -1,0 +1,51 @@
+package io.github.temporalrift.game.action.application.command;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.github.temporalrift.game.action.application.port.in.PlaySpecialActionUseCase;
+import io.github.temporalrift.game.action.domain.actionround.RoundNotFoundException;
+import io.github.temporalrift.game.action.domain.playerstate.PlayerStateNotFoundException;
+import io.github.temporalrift.game.action.domain.port.out.ActionRoundRepository;
+import io.github.temporalrift.game.action.domain.port.out.PlayerStateRepository;
+
+@Service
+class PlaySpecialActionCommandHandler implements PlaySpecialActionUseCase {
+
+    private final ActionRoundRepository actionRoundRepository;
+
+    private final PlayerStateRepository playerStateRepository;
+
+    PlaySpecialActionCommandHandler(
+            ActionRoundRepository actionRoundRepository, PlayerStateRepository playerStateRepository) {
+        this.actionRoundRepository = actionRoundRepository;
+        this.playerStateRepository = playerStateRepository;
+    }
+
+    @Override
+    @Transactional
+    public Result handle(Command command) {
+        var round = actionRoundRepository
+                .findByGameIdAndEraNumberAndRoundNumber(command.gameId(), command.eraNumber(), command.roundNumber())
+                .orElseThrow(
+                        () -> new RoundNotFoundException(command.gameId(), command.eraNumber(), command.roundNumber()));
+        var playerState = playerStateRepository
+                .findByGameIdAndPlayerId(command.gameId(), command.playerId())
+                .orElseThrow(() -> new PlayerStateNotFoundException(command.gameId(), command.playerId()));
+        var allSubmitted = round.submitSpecial(
+                command.playerId(),
+                command.faction(),
+                command.specialAction(),
+                command.targetEventId(),
+                command.targetOutcomeId(),
+                command.targetPlayerId(),
+                playerState.isJammed());
+        if (allSubmitted) {
+            round.close("ALL_SUBMITTED");
+        }
+        actionRoundRepository.save(round);
+
+        return new Result(
+                command.gameId(), command.eraNumber(), command.roundNumber(), command.playerId(), allSubmitted);
+    }
+}

--- a/src/main/java/io/github/temporalrift/game/action/application/command/PlaySpecialActionCommandHandler.java
+++ b/src/main/java/io/github/temporalrift/game/action/application/command/PlaySpecialActionCommandHandler.java
@@ -1,5 +1,6 @@
 package io.github.temporalrift.game.action.application.command;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,6 +11,7 @@ import io.github.temporalrift.game.action.domain.port.out.ActionRoundRepository;
 import io.github.temporalrift.game.action.domain.port.out.PlayerStateRepository;
 
 @Service
+@ConditionalOnBean({ActionRoundRepository.class, PlayerStateRepository.class})
 class PlaySpecialActionCommandHandler implements PlaySpecialActionUseCase {
 
     private final ActionRoundRepository actionRoundRepository;

--- a/src/main/java/io/github/temporalrift/game/action/application/port/in/PlayCardUseCase.java
+++ b/src/main/java/io/github/temporalrift/game/action/application/port/in/PlayCardUseCase.java
@@ -1,0 +1,22 @@
+package io.github.temporalrift.game.action.application.port.in;
+
+import java.util.UUID;
+
+import io.github.temporalrift.events.shared.CardType;
+
+public interface PlayCardUseCase {
+
+    Result handle(Command command);
+
+    record Command(
+            UUID gameId,
+            int eraNumber,
+            int roundNumber,
+            UUID playerId,
+            UUID cardInstanceId,
+            CardType cardType,
+            UUID targetEventId,
+            UUID targetOutcomeId) {}
+
+    record Result(UUID gameId, int eraNumber, int roundNumber, UUID playerId, boolean roundClosed) {}
+}

--- a/src/main/java/io/github/temporalrift/game/action/application/port/in/PlaySpecialActionUseCase.java
+++ b/src/main/java/io/github/temporalrift/game/action/application/port/in/PlaySpecialActionUseCase.java
@@ -1,0 +1,24 @@
+package io.github.temporalrift.game.action.application.port.in;
+
+import java.util.UUID;
+
+import io.github.temporalrift.events.shared.Faction;
+import io.github.temporalrift.events.shared.SpecialAction;
+
+public interface PlaySpecialActionUseCase {
+
+    Result handle(Command command);
+
+    record Command(
+            UUID gameId,
+            int eraNumber,
+            int roundNumber,
+            UUID playerId,
+            Faction faction,
+            SpecialAction specialAction,
+            UUID targetEventId,
+            UUID targetOutcomeId,
+            UUID targetPlayerId) {}
+
+    record Result(UUID gameId, int eraNumber, int roundNumber, UUID playerId, boolean roundClosed) {}
+}

--- a/src/main/java/io/github/temporalrift/game/action/domain/actionround/RoundNotFoundException.java
+++ b/src/main/java/io/github/temporalrift/game/action/domain/actionround/RoundNotFoundException.java
@@ -1,0 +1,10 @@
+package io.github.temporalrift.game.action.domain.actionround;
+
+import java.util.UUID;
+
+public class RoundNotFoundException extends RuntimeException {
+
+    public RoundNotFoundException(UUID gameId, int eraNumber, int roundNumber) {
+        super("No action round found for game " + gameId + " era " + eraNumber + " round " + roundNumber);
+    }
+}

--- a/src/main/java/io/github/temporalrift/game/action/domain/playerstate/PlayerStateNotFoundException.java
+++ b/src/main/java/io/github/temporalrift/game/action/domain/playerstate/PlayerStateNotFoundException.java
@@ -1,0 +1,10 @@
+package io.github.temporalrift.game.action.domain.playerstate;
+
+import java.util.UUID;
+
+public class PlayerStateNotFoundException extends RuntimeException {
+
+    public PlayerStateNotFoundException(UUID gameId, UUID playerId) {
+        super("No player state found for player " + playerId + " in game " + gameId);
+    }
+}

--- a/src/test/java/io/github/temporalrift/game/action/application/command/PlayCardCommandHandlerTest.java
+++ b/src/test/java/io/github/temporalrift/game/action/application/command/PlayCardCommandHandlerTest.java
@@ -1,0 +1,222 @@
+package io.github.temporalrift.game.action.application.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.github.temporalrift.events.shared.CardType;
+import io.github.temporalrift.game.action.application.port.in.PlayCardUseCase;
+import io.github.temporalrift.game.action.domain.CardNotInHandException;
+import io.github.temporalrift.game.action.domain.actionround.ActionRound;
+import io.github.temporalrift.game.action.domain.actionround.ActionRoundClosedException;
+import io.github.temporalrift.game.action.domain.actionround.DuplicateSubmissionException;
+import io.github.temporalrift.game.action.domain.actionround.RoundNotFoundException;
+import io.github.temporalrift.game.action.domain.playerstate.PlayerState;
+import io.github.temporalrift.game.action.domain.playerstate.PlayerStateNotFoundException;
+import io.github.temporalrift.game.action.domain.port.out.ActionRoundRepository;
+import io.github.temporalrift.game.action.domain.port.out.PlayerStateRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PlayCardCommandHandler")
+class PlayCardCommandHandlerTest {
+
+    static final UUID GAME_ID = UUID.randomUUID();
+    static final UUID PLAYER_ID = UUID.randomUUID();
+    static final UUID CARD_INSTANCE_ID = UUID.randomUUID();
+    static final int ERA = 1;
+    static final int ROUND = 1;
+
+    @Mock
+    ActionRoundRepository actionRoundRepository;
+
+    @Mock
+    PlayerStateRepository playerStateRepository;
+
+    @Mock
+    ActionRound round;
+
+    @Mock
+    PlayerState playerState;
+
+    @InjectMocks
+    PlayCardCommandHandler handler;
+
+    @Test
+    @DisplayName("handle — happy path — saves round and player state, returns result")
+    void handleHappyPath() {
+        // given
+        var cardInstanceId = UUID.randomUUID();
+        var command = new PlayCardUseCase.Command(
+                GAME_ID, ERA, ROUND, PLAYER_ID, cardInstanceId, CardType.PUSH, UUID.randomUUID(), UUID.randomUUID());
+        given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(round));
+        given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.of(playerState));
+        given(playerState.hand()).willReturn(List.of(new PlayerState.CardInstance(cardInstanceId, CardType.PUSH)));
+        given(round.submitCard(eq(PLAYER_ID), eq(cardInstanceId), eq(CardType.PUSH), any(), any(), anyList()))
+                .willReturn(false);
+
+        // when
+        var result = handler.handle(command);
+
+        // then
+        then(actionRoundRepository).should().save(round);
+        then(playerStateRepository).should().save(playerState);
+        assertThat(result.gameId()).isEqualTo(GAME_ID);
+        assertThat(result.eraNumber()).isEqualTo(ERA);
+        assertThat(result.roundNumber()).isEqualTo(ROUND);
+        assertThat(result.playerId()).isEqualTo(PLAYER_ID);
+        assertThat(result.roundClosed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("handle — all players submitted — calls close on round and returns roundClosed true")
+    void handleAllSubmittedClosesRound() {
+        // given
+        var cardInstanceId = UUID.randomUUID();
+        var command =
+                new PlayCardUseCase.Command(GAME_ID, ERA, ROUND, PLAYER_ID, cardInstanceId, CardType.PUSH, null, null);
+        given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(round));
+        given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.of(playerState));
+        given(playerState.hand()).willReturn(List.of(new PlayerState.CardInstance(cardInstanceId, CardType.PUSH)));
+        given(round.submitCard(any(), any(), any(), any(), any(), anyList())).willReturn(true);
+
+        // when
+        var result = handler.handle(command);
+
+        // then
+        then(round).should().close("ALL_SUBMITTED");
+        assertThat(result.roundClosed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("handle — round not found — throws RoundNotFoundException")
+    void handleRoundNotFound() {
+        // given
+        given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.empty());
+        var command = new PlayCardUseCase.Command(
+                GAME_ID, ERA, ROUND, PLAYER_ID, UUID.randomUUID(), CardType.PUSH, null, null);
+
+        // when / then
+        assertThatExceptionOfType(RoundNotFoundException.class).isThrownBy(() -> handler.handle(command));
+    }
+
+    @Test
+    @DisplayName("handle — player state not found — throws PlayerStateNotFoundException")
+    void handlePlayerStateNotFound() {
+        // given
+        given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(round));
+        given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.empty());
+        var command = new PlayCardUseCase.Command(
+                GAME_ID, ERA, ROUND, PLAYER_ID, UUID.randomUUID(), CardType.PUSH, null, null);
+
+        // when / then
+        assertThatExceptionOfType(PlayerStateNotFoundException.class).isThrownBy(() -> handler.handle(command));
+    }
+
+    @Test
+    @DisplayName("handle — round is closed — propagates ActionRoundClosedException")
+    void handleRoundClosed() {
+        // given
+        given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(round));
+        given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.of(playerState));
+        given(playerState.hand()).willReturn(List.of(new PlayerState.CardInstance(CARD_INSTANCE_ID, CardType.PUSH)));
+        willThrow(new ActionRoundClosedException())
+                .given(round)
+                .submitCard(any(), any(), any(), any(), any(), anyList());
+        var command = new PlayCardUseCase.Command(
+                GAME_ID, ERA, ROUND, PLAYER_ID, CARD_INSTANCE_ID, CardType.PUSH, null, null);
+
+        // when / then
+        assertThatExceptionOfType(ActionRoundClosedException.class).isThrownBy(() -> handler.handle(command));
+    }
+
+    @Test
+    @DisplayName("handle — card not in hand — propagates CardNotInHandException")
+    void handleCardNotInHand() {
+        // given
+        given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(round));
+        given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.of(playerState));
+        given(playerState.hand()).willReturn(List.of());
+        willThrow(new CardNotInHandException(CARD_INSTANCE_ID))
+                .given(round)
+                .submitCard(any(), any(), any(), any(), any(), anyList());
+        var command = new PlayCardUseCase.Command(
+                GAME_ID, ERA, ROUND, PLAYER_ID, CARD_INSTANCE_ID, CardType.PUSH, null, null);
+
+        // when / then
+        assertThatExceptionOfType(CardNotInHandException.class).isThrownBy(() -> handler.handle(command));
+    }
+
+    @Test
+    @DisplayName("handle — player already submitted — propagates DuplicateSubmissionException")
+    void handleDuplicateSubmission() {
+        // given
+        given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(round));
+        given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.of(playerState));
+        given(playerState.hand()).willReturn(List.of(new PlayerState.CardInstance(CARD_INSTANCE_ID, CardType.PUSH)));
+        willThrow(new DuplicateSubmissionException(PLAYER_ID))
+                .given(round)
+                .submitCard(any(), any(), any(), any(), any(), anyList());
+        var command = new PlayCardUseCase.Command(
+                GAME_ID, ERA, ROUND, PLAYER_ID, CARD_INSTANCE_ID, CardType.PUSH, null, null);
+
+        // when / then
+        assertThatExceptionOfType(DuplicateSubmissionException.class).isThrownBy(() -> handler.handle(command));
+    }
+
+    @Test
+    @DisplayName("handle — submits player hand UUIDs to submitCard")
+    void handleSubmitsHandUuids() {
+        // given
+        var c1 = new PlayerState.CardInstance(UUID.randomUUID(), CardType.PUSH);
+        var c2 = new PlayerState.CardInstance(UUID.randomUUID(), CardType.JAM);
+        given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(round));
+        given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.of(playerState));
+        given(playerState.hand()).willReturn(List.of(c1, c2));
+        given(round.submitCard(any(), any(), any(), any(), any(), anyList())).willReturn(false);
+        var command = new PlayCardUseCase.Command(
+                GAME_ID, ERA, ROUND, PLAYER_ID, c1.cardInstanceId(), CardType.PUSH, null, null);
+
+        // when
+        handler.handle(command);
+
+        // then
+        @SuppressWarnings("unchecked")
+        var captor = ArgumentCaptor.forClass(List.class);
+        then(round)
+                .should()
+                .submitCard(
+                        eq(PLAYER_ID),
+                        eq(c1.cardInstanceId()),
+                        eq(CardType.PUSH),
+                        isNull(),
+                        isNull(),
+                        captor.capture());
+        assertThat(captor.getValue()).containsExactlyInAnyOrder(c1.cardInstanceId(), c2.cardInstanceId());
+    }
+}

--- a/src/test/java/io/github/temporalrift/game/action/application/command/PlaySpecialActionCommandHandlerTest.java
+++ b/src/test/java/io/github/temporalrift/game/action/application/command/PlaySpecialActionCommandHandlerTest.java
@@ -1,0 +1,225 @@
+package io.github.temporalrift.game.action.application.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.github.temporalrift.events.shared.Faction;
+import io.github.temporalrift.events.shared.SpecialAction;
+import io.github.temporalrift.game.action.application.port.in.PlaySpecialActionUseCase;
+import io.github.temporalrift.game.action.domain.actionround.ActionRound;
+import io.github.temporalrift.game.action.domain.actionround.ActionRoundClosedException;
+import io.github.temporalrift.game.action.domain.actionround.DuplicateSubmissionException;
+import io.github.temporalrift.game.action.domain.actionround.JammedPlayerException;
+import io.github.temporalrift.game.action.domain.actionround.RoundNotFoundException;
+import io.github.temporalrift.game.action.domain.playerstate.PlayerState;
+import io.github.temporalrift.game.action.domain.playerstate.PlayerStateNotFoundException;
+import io.github.temporalrift.game.action.domain.port.out.ActionRoundRepository;
+import io.github.temporalrift.game.action.domain.port.out.PlayerStateRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PlaySpecialActionCommandHandler")
+class PlaySpecialActionCommandHandlerTest {
+
+    static final UUID GAME_ID = UUID.randomUUID();
+    static final UUID PLAYER_ID = UUID.randomUUID();
+    static final int ERA = 1;
+    static final int ROUND = 1;
+
+    @Mock
+    ActionRoundRepository actionRoundRepository;
+
+    @Mock
+    PlayerStateRepository playerStateRepository;
+
+    @Mock
+    ActionRound round;
+
+    @Mock
+    PlayerState playerState;
+
+    @InjectMocks
+    PlaySpecialActionCommandHandler handler;
+
+    @Test
+    @DisplayName("handle — happy path — saves round, does not save player state, returns result")
+    void handleHappyPath() {
+        // given
+        var command = new PlaySpecialActionUseCase.Command(
+                GAME_ID,
+                ERA,
+                ROUND,
+                PLAYER_ID,
+                Faction.ERASERS,
+                SpecialAction.ANNIHILATE,
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                null);
+        given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(round));
+        given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.of(playerState));
+        given(playerState.isJammed()).willReturn(false);
+        given(round.submitSpecial(any(), any(), any(), any(), any(), any(), anyBoolean()))
+                .willReturn(false);
+
+        // when
+        var result = handler.handle(command);
+
+        // then
+        then(actionRoundRepository).should().save(round);
+        then(playerStateRepository).should(never()).save(any());
+        assertThat(result.gameId()).isEqualTo(GAME_ID);
+        assertThat(result.eraNumber()).isEqualTo(ERA);
+        assertThat(result.roundNumber()).isEqualTo(ROUND);
+        assertThat(result.playerId()).isEqualTo(PLAYER_ID);
+        assertThat(result.roundClosed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("handle — all players submitted — calls close on round and returns roundClosed true")
+    void handleAllSubmittedClosesRound() {
+        // given
+        var command = new PlaySpecialActionUseCase.Command(
+                GAME_ID, ERA, ROUND, PLAYER_ID, Faction.PROPHETS, SpecialAction.SEAL, null, null, null);
+        given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(round));
+        given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.of(playerState));
+        given(playerState.isJammed()).willReturn(false);
+        given(round.submitSpecial(any(), any(), any(), any(), any(), any(), anyBoolean()))
+                .willReturn(true);
+
+        // when
+        var result = handler.handle(command);
+
+        // then
+        then(round).should().close("ALL_SUBMITTED");
+        assertThat(result.roundClosed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("handle — round not found — throws RoundNotFoundException")
+    void handleRoundNotFound() {
+        // given
+        given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.empty());
+        var command = new PlaySpecialActionUseCase.Command(
+                GAME_ID, ERA, ROUND, PLAYER_ID, Faction.PROPHETS, SpecialAction.SEAL, null, null, null);
+
+        // when / then
+        assertThatExceptionOfType(RoundNotFoundException.class).isThrownBy(() -> handler.handle(command));
+    }
+
+    @Test
+    @DisplayName("handle — player state not found — throws PlayerStateNotFoundException")
+    void handlePlayerStateNotFound() {
+        // given
+        given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(round));
+        given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.empty());
+        var command = new PlaySpecialActionUseCase.Command(
+                GAME_ID, ERA, ROUND, PLAYER_ID, Faction.PROPHETS, SpecialAction.SEAL, null, null, null);
+
+        // when / then
+        assertThatExceptionOfType(PlayerStateNotFoundException.class).isThrownBy(() -> handler.handle(command));
+    }
+
+    @Test
+    @DisplayName("handle — player is jammed — propagates JammedPlayerException from aggregate")
+    void handleJammedPlayer() {
+        // given
+        var command = new PlaySpecialActionUseCase.Command(
+                GAME_ID, ERA, ROUND, PLAYER_ID, Faction.ERASERS, SpecialAction.ANNIHILATE, null, null, null);
+        given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(round));
+        given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.of(playerState));
+        given(playerState.isJammed()).willReturn(true);
+        willThrow(new JammedPlayerException(PLAYER_ID))
+                .given(round)
+                .submitSpecial(any(), any(), any(), any(), any(), any(), eq(true));
+
+        // when / then
+        assertThatExceptionOfType(JammedPlayerException.class).isThrownBy(() -> handler.handle(command));
+    }
+
+    @Test
+    @DisplayName("handle — round is closed — propagates ActionRoundClosedException")
+    void handleRoundClosed() {
+        // given
+        given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(round));
+        given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.of(playerState));
+        given(playerState.isJammed()).willReturn(false);
+        willThrow(new ActionRoundClosedException())
+                .given(round)
+                .submitSpecial(any(), any(), any(), any(), any(), any(), anyBoolean());
+        var command = new PlaySpecialActionUseCase.Command(
+                GAME_ID, ERA, ROUND, PLAYER_ID, Faction.PROPHETS, SpecialAction.SEAL, null, null, null);
+
+        // when / then
+        assertThatExceptionOfType(ActionRoundClosedException.class).isThrownBy(() -> handler.handle(command));
+    }
+
+    @Test
+    @DisplayName("handle — player already submitted — propagates DuplicateSubmissionException")
+    void handleDuplicateSubmission() {
+        // given
+        given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(round));
+        given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.of(playerState));
+        given(playerState.isJammed()).willReturn(false);
+        willThrow(new DuplicateSubmissionException(PLAYER_ID))
+                .given(round)
+                .submitSpecial(any(), any(), any(), any(), any(), any(), anyBoolean());
+        var command = new PlaySpecialActionUseCase.Command(
+                GAME_ID, ERA, ROUND, PLAYER_ID, Faction.PROPHETS, SpecialAction.SEAL, null, null, null);
+
+        // when / then
+        assertThatExceptionOfType(DuplicateSubmissionException.class).isThrownBy(() -> handler.handle(command));
+    }
+
+    @Test
+    @DisplayName("handle — passes isJammed value to submitSpecial")
+    void handlePassesIsJammedToAggregate() {
+        // given
+        var command = new PlaySpecialActionUseCase.Command(
+                GAME_ID, ERA, ROUND, PLAYER_ID, Faction.ERASERS, SpecialAction.CORRUPT, null, null, UUID.randomUUID());
+        given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(round));
+        given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.of(playerState));
+        given(playerState.isJammed()).willReturn(false);
+        given(round.submitSpecial(any(), any(), any(), any(), any(), any(), anyBoolean()))
+                .willReturn(false);
+
+        // when
+        handler.handle(command);
+
+        // then
+        then(round)
+                .should()
+                .submitSpecial(
+                        eq(PLAYER_ID),
+                        eq(Faction.ERASERS),
+                        eq(SpecialAction.CORRUPT),
+                        isNull(),
+                        isNull(),
+                        any(),
+                        eq(false));
+    }
+}


### PR DESCRIPTION
## Summary

Implements `PlayCardCommandHandler` and `PlaySpecialActionCommandHandler` — the two core action module command handlers that process card/special-action submissions during an action round, closing #28.

## What changed

- **Driving ports** (`application/port/in/`): `PlayCardUseCase` and `PlaySpecialActionUseCase` interfaces with nested `Command`/`Result` records. Removed the `.gitkeep` placeholder.
- **`PlayCardCommandHandler`** — loads the `ActionRound` and `PlayerState`, extracts the player's hand as UUIDs, delegates to `round.submitCard(...)`, removes the card from `playerState.hand`, and saves both aggregates. Closes the round when all players have submitted.
- **`PlaySpecialActionCommandHandler`** — same round/player-state lookup flow but delegates to `round.submitSpecial(...)`, reads `isJammed` from `PlayerState` and forwards it to the aggregate for validation. Does **not** save `PlayerState` (special actions don't mutate the hand).
- **Domain exceptions**: `RoundNotFoundException` and `PlayerStateNotFoundException` (both `RuntimeException`).
- **Tests** — 16 unit tests across the two handlers, covering happy path, all-submitted round-close, not-found scenarios, and propagation of aggregate exceptions (`ActionRoundClosedException`, `CardNotInHandException`, `DuplicateSubmissionException`, `JammedPlayerException`).

## Files

| File | Change |
|---|---|
| `PlayCardUseCase.java` | new driving port interface |
| `PlaySpecialActionUseCase.java` | new driving port interface |
| `PlayCardCommandHandler.java` | new command handler |
| `PlaySpecialActionCommandHandler.java` | new command handler |
| `RoundNotFoundException.java` | new domain exception |
| `PlayerStateNotFoundException.java` | new domain exception |
| `PlayCardCommandHandlerTest.java` | 8 tests |
| `PlaySpecialActionCommandHandlerTest.java` | 8 tests |
| `.gitkeep` | removed (port/in now has real files) |