### PR TITLE
feat(action): expose action round REST endpoints

### DIFF
--- a/src/main/java/io/github/temporalrift/game/action/application/command/PlayCardCommandHandler.java
+++ b/src/main/java/io/github/temporalrift/game/action/application/command/PlayCardCommandHandler.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import io.github.temporalrift.events.envelope.EventEnvelope;
 import io.github.temporalrift.game.action.application.port.in.PlayCardUseCase;
+import io.github.temporalrift.game.action.domain.CardNotInHandException;
 import io.github.temporalrift.game.action.domain.actionround.ActionRound;
 import io.github.temporalrift.game.action.domain.actionround.RoundNotFoundException;
 import io.github.temporalrift.game.action.domain.playerstate.PlayerState;
@@ -46,10 +47,14 @@ class PlayCardCommandHandler implements PlayCardUseCase {
         var playerHand = playerState.hand().stream()
                 .map(PlayerState.CardInstance::cardInstanceId)
                 .toList();
+        var submittedCard = playerState.hand().stream()
+                .filter(card -> card.cardInstanceId().equals(command.cardInstanceId()))
+                .findFirst()
+                .orElseThrow(() -> new CardNotInHandException(command.cardInstanceId()));
         var allSubmitted = round.submitCard(
                 command.playerId(),
                 command.cardInstanceId(),
-                command.cardType(),
+                submittedCard.cardType(),
                 command.targetEventId(),
                 command.sourceOutcomeId(),
                 command.targetOutcomeId(),

--- a/src/main/java/io/github/temporalrift/game/action/application/command/PlaySpecialActionCommandHandler.java
+++ b/src/main/java/io/github/temporalrift/game/action/application/command/PlaySpecialActionCommandHandler.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import io.github.temporalrift.events.envelope.EventEnvelope;
 import io.github.temporalrift.game.action.application.port.in.PlaySpecialActionUseCase;
 import io.github.temporalrift.game.action.domain.actionround.ActionRound;
+import io.github.temporalrift.game.action.domain.actionround.FactionRequiredException;
 import io.github.temporalrift.game.action.domain.actionround.RoundNotFoundException;
 import io.github.temporalrift.game.action.domain.playerstate.PlayerStateNotFoundException;
 import io.github.temporalrift.game.action.domain.port.out.ActionEventPublisher;
@@ -42,9 +43,13 @@ class PlaySpecialActionCommandHandler implements PlaySpecialActionUseCase {
         var playerState = playerStateRepository
                 .findByGameIdAndPlayerId(command.gameId(), command.playerId())
                 .orElseThrow(() -> new PlayerStateNotFoundException(command.gameId(), command.playerId()));
+        var faction = playerState.faction();
+        if (faction == null) {
+            throw new FactionRequiredException(command.playerId());
+        }
         var allSubmitted = round.submitSpecial(
                 command.playerId(),
-                command.faction(),
+                faction,
                 command.specialAction(),
                 command.targetEventId(),
                 command.targetOutcomeId(),

--- a/src/main/java/io/github/temporalrift/game/action/application/port/in/GetRoundStatusUseCase.java
+++ b/src/main/java/io/github/temporalrift/game/action/application/port/in/GetRoundStatusUseCase.java
@@ -1,0 +1,23 @@
+package io.github.temporalrift.game.action.application.port.in;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Reads public submission status for a normal action round.
+ */
+public interface GetRoundStatusUseCase {
+
+    Result handle(Query query);
+
+    record Query(UUID gameId, int eraNumber, int roundNumber) {}
+
+    record Result(
+            int eraNumber,
+            int roundNumber,
+            String status,
+            int timerRemainingSeconds,
+            int submittedCount,
+            int totalPlayers,
+            List<UUID> pendingPlayerIds) {}
+}

--- a/src/main/java/io/github/temporalrift/game/action/application/port/in/PlayCardUseCase.java
+++ b/src/main/java/io/github/temporalrift/game/action/application/port/in/PlayCardUseCase.java
@@ -2,8 +2,6 @@ package io.github.temporalrift.game.action.application.port.in;
 
 import java.util.UUID;
 
-import io.github.temporalrift.events.shared.CardType;
-
 /**
  * Accepts a player's card submission for an open action round.
  *
@@ -27,7 +25,6 @@ public interface PlayCardUseCase {
             int roundNumber,
             UUID playerId,
             UUID cardInstanceId,
-            CardType cardType,
             UUID targetEventId,
             UUID sourceOutcomeId,
             UUID targetOutcomeId) {}

--- a/src/main/java/io/github/temporalrift/game/action/application/port/in/PlaySpecialActionUseCase.java
+++ b/src/main/java/io/github/temporalrift/game/action/application/port/in/PlaySpecialActionUseCase.java
@@ -2,7 +2,6 @@ package io.github.temporalrift.game.action.application.port.in;
 
 import java.util.UUID;
 
-import io.github.temporalrift.events.shared.Faction;
 import io.github.temporalrift.events.shared.SpecialAction;
 
 /**
@@ -27,7 +26,6 @@ public interface PlaySpecialActionUseCase {
             int eraNumber,
             int roundNumber,
             UUID playerId,
-            Faction faction,
             SpecialAction specialAction,
             UUID targetEventId,
             UUID targetOutcomeId,

--- a/src/main/java/io/github/temporalrift/game/action/application/query/GetRoundStatusQueryHandler.java
+++ b/src/main/java/io/github/temporalrift/game/action/application/query/GetRoundStatusQueryHandler.java
@@ -1,0 +1,71 @@
+package io.github.temporalrift.game.action.application.query;
+
+import java.time.Clock;
+import java.time.Duration;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.github.temporalrift.game.action.application.port.in.GetRoundStatusUseCase;
+import io.github.temporalrift.game.action.domain.actionround.RoundNotFoundException;
+import io.github.temporalrift.game.action.domain.actionround.RoundStatus;
+import io.github.temporalrift.game.action.domain.port.out.ActionRoundRepository;
+import io.github.temporalrift.game.action.domain.port.out.ActionRoundSagaRepository;
+import io.github.temporalrift.game.action.domain.saga.ActionRoundSagaState;
+
+@Service
+@ConditionalOnBean({ActionRoundRepository.class, ActionRoundSagaRepository.class})
+class GetRoundStatusQueryHandler implements GetRoundStatusUseCase {
+
+    private final ActionRoundRepository actionRoundRepository;
+
+    private final ActionRoundSagaRepository actionRoundSagaRepository;
+
+    private final Clock clock;
+
+    GetRoundStatusQueryHandler(
+            ActionRoundRepository actionRoundRepository,
+            ActionRoundSagaRepository actionRoundSagaRepository,
+            Clock clock) {
+        this.actionRoundRepository = actionRoundRepository;
+        this.actionRoundSagaRepository = actionRoundSagaRepository;
+        this.clock = clock;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Result handle(Query query) {
+        var round = actionRoundRepository
+                .findByGameIdAndEraNumberAndRoundNumber(query.gameId(), query.eraNumber(), query.roundNumber())
+                .orElseThrow(() -> new RoundNotFoundException(query.gameId(), query.eraNumber(), query.roundNumber()));
+        var sagaState = actionRoundSagaRepository.findByGameIdAndEraNumberAndRoundNumber(
+                query.gameId(), query.eraNumber(), query.roundNumber());
+        var timerRemainingSeconds = sagaState.map(this::timerRemainingSeconds).orElse(0);
+        var pendingPlayerIds =
+                sagaState.map(ActionRoundSagaState::pendingPlayerIds).orElseGet(round::pendingPlayerIds);
+        var submittedCount = round.submittedActions().size();
+
+        return new Result(
+                round.eraNumber(),
+                round.roundNumber(),
+                restStatus(round.status()),
+                timerRemainingSeconds,
+                submittedCount,
+                pendingPlayerIds.size() + submittedCount,
+                pendingPlayerIds);
+    }
+
+    private int timerRemainingSeconds(ActionRoundSagaState state) {
+        var remainingSeconds =
+                Duration.between(clock.instant(), state.timerExpiresAt()).toSeconds();
+        return Math.clamp(remainingSeconds, 0, Integer.MAX_VALUE);
+    }
+
+    private String restStatus(RoundStatus status) {
+        return switch (status) {
+            case OPEN -> "OPEN";
+            case CLOSING, CLOSED -> "CLOSED";
+        };
+    }
+}

--- a/src/main/java/io/github/temporalrift/game/action/domain/actionround/ActionRound.java
+++ b/src/main/java/io/github/temporalrift/game/action/domain/actionround/ActionRound.java
@@ -158,6 +158,9 @@ public class ActionRound extends AggregateRoot {
         if (isJammed) {
             throw new JammedPlayerException(playerId);
         }
+        if (faction == null) {
+            throw new FactionRequiredException(playerId);
+        }
 
         pendingPlayerIds.remove(playerId);
         submittedActions.add(new SubmittedAction.SpecialActionSubmission(

--- a/src/main/java/io/github/temporalrift/game/action/domain/actionround/FactionRequiredException.java
+++ b/src/main/java/io/github/temporalrift/game/action/domain/actionround/FactionRequiredException.java
@@ -1,0 +1,10 @@
+package io.github.temporalrift.game.action.domain.actionround;
+
+import java.util.UUID;
+
+public class FactionRequiredException extends RuntimeException {
+
+    public FactionRequiredException(UUID playerId) {
+        super("Player " + playerId + " must have an assigned faction to submit a special action");
+    }
+}

--- a/src/main/java/io/github/temporalrift/game/action/infrastructure/adapter/in/rest/ActionController.java
+++ b/src/main/java/io/github/temporalrift/game/action/infrastructure/adapter/in/rest/ActionController.java
@@ -1,0 +1,113 @@
+package io.github.temporalrift.game.action.infrastructure.adapter.in.rest;
+
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.github.temporalrift.game.action.application.port.in.GetRoundStatusUseCase;
+import io.github.temporalrift.game.action.application.port.in.PlayCardUseCase;
+import io.github.temporalrift.game.action.application.port.in.PlaySpecialActionUseCase;
+import io.github.temporalrift.game.action.infrastructure.adapter.in.rest.model.ActionSubmissionStatus;
+import io.github.temporalrift.game.action.infrastructure.adapter.in.rest.model.CardActionRequest;
+import io.github.temporalrift.game.action.infrastructure.adapter.in.rest.model.RoundStatus;
+import io.github.temporalrift.game.action.infrastructure.adapter.in.rest.model.RoundStatusResponse;
+import io.github.temporalrift.game.action.infrastructure.adapter.in.rest.model.SpecialActionRequest;
+import io.github.temporalrift.game.action.infrastructure.adapter.in.rest.model.SubmitActionRequest;
+import io.github.temporalrift.game.action.infrastructure.adapter.in.rest.model.SubmitActionResponse;
+import io.github.temporalrift.game.shared.PlayerPrincipal;
+
+@RestController
+class ActionController implements ActionApi {
+
+    private final PlayCardUseCase playCardUseCase;
+
+    private final PlaySpecialActionUseCase playSpecialActionUseCase;
+
+    private final GetRoundStatusUseCase getRoundStatusUseCase;
+
+    ActionController(
+            PlayCardUseCase playCardUseCase,
+            PlaySpecialActionUseCase playSpecialActionUseCase,
+            GetRoundStatusUseCase getRoundStatusUseCase) {
+        this.playCardUseCase = playCardUseCase;
+        this.playSpecialActionUseCase = playSpecialActionUseCase;
+        this.getRoundStatusUseCase = getRoundStatusUseCase;
+    }
+
+    @Override
+    public ResponseEntity<SubmitActionResponse> submitAction(
+            UUID gameId, Integer eraNumber, Integer roundNumber, SubmitActionRequest submitActionRequest) {
+        var playerId = callerPlayerId();
+        var result =
+                switch (submitActionRequest.getActionType()) {
+                    case CARD ->
+                        submitCard(gameId, eraNumber, roundNumber, playerId, (CardActionRequest) submitActionRequest);
+                    case SPECIAL ->
+                        submitSpecial(
+                                gameId, eraNumber, roundNumber, playerId, (SpecialActionRequest) submitActionRequest);
+                };
+
+        return ResponseEntity.accepted()
+                .body(new SubmitActionResponse(
+                        result.gameId(),
+                        result.eraNumber(),
+                        result.roundNumber(),
+                        result.playerId(),
+                        ActionSubmissionStatus.SUBMITTED,
+                        result.roundClosed()));
+    }
+
+    @Override
+    public ResponseEntity<RoundStatusResponse> getRoundStatus(UUID gameId, Integer eraNumber, Integer roundNumber) {
+        var result = getRoundStatusUseCase.handle(new GetRoundStatusUseCase.Query(gameId, eraNumber, roundNumber));
+        return ResponseEntity.ok(new RoundStatusResponse(
+                result.eraNumber(),
+                result.roundNumber(),
+                RoundStatus.fromValue(result.status()),
+                result.timerRemainingSeconds(),
+                result.submittedCount(),
+                result.totalPlayers(),
+                result.pendingPlayerIds()));
+    }
+
+    private SubmissionResult submitCard(
+            UUID gameId, int eraNumber, int roundNumber, UUID playerId, CardActionRequest request) {
+        var result = playCardUseCase.handle(new PlayCardUseCase.Command(
+                gameId,
+                eraNumber,
+                roundNumber,
+                playerId,
+                request.getCardInstanceId(),
+                request.getTargetEventId(),
+                request.getSourceOutcomeId(),
+                request.getTargetOutcomeId()));
+        return new SubmissionResult(
+                result.gameId(), result.eraNumber(), result.roundNumber(), result.playerId(), result.roundClosed());
+    }
+
+    private SubmissionResult submitSpecial(
+            UUID gameId, int eraNumber, int roundNumber, UUID playerId, SpecialActionRequest request) {
+        var result = playSpecialActionUseCase.handle(new PlaySpecialActionUseCase.Command(
+                gameId,
+                eraNumber,
+                roundNumber,
+                playerId,
+                io.github.temporalrift.events.shared.SpecialAction.valueOf(
+                        request.getSpecialAction().name()),
+                request.getTargetEventId(),
+                request.getTargetOutcomeId(),
+                request.getTargetPlayerId()));
+        return new SubmissionResult(
+                result.gameId(), result.eraNumber(), result.roundNumber(), result.playerId(), result.roundClosed());
+    }
+
+    private UUID callerPlayerId() {
+        return ((PlayerPrincipal)
+                        SecurityContextHolder.getContext().getAuthentication().getPrincipal())
+                .playerId();
+    }
+
+    private record SubmissionResult(UUID gameId, int eraNumber, int roundNumber, UUID playerId, boolean roundClosed) {}
+}

--- a/src/main/java/io/github/temporalrift/game/action/infrastructure/adapter/in/rest/ActionExceptionHandler.java
+++ b/src/main/java/io/github/temporalrift/game/action/infrastructure/adapter/in/rest/ActionExceptionHandler.java
@@ -1,0 +1,39 @@
+package io.github.temporalrift.game.action.infrastructure.adapter.in.rest;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import io.github.temporalrift.game.action.domain.CardNotInHandException;
+import io.github.temporalrift.game.action.domain.actionround.ActionRoundClosedException;
+import io.github.temporalrift.game.action.domain.actionround.DuplicateSubmissionException;
+import io.github.temporalrift.game.action.domain.actionround.FactionRequiredException;
+import io.github.temporalrift.game.action.domain.actionround.InvalidActionTargetException;
+import io.github.temporalrift.game.action.domain.actionround.JammedPlayerException;
+import io.github.temporalrift.game.action.domain.actionround.RoundNotFoundException;
+import io.github.temporalrift.game.action.domain.playerstate.PlayerStateNotFoundException;
+
+@RestControllerAdvice(basePackageClasses = ActionController.class)
+class ActionExceptionHandler {
+
+    @ExceptionHandler({RoundNotFoundException.class, PlayerStateNotFoundException.class})
+    ProblemDetail handleNotFound(RuntimeException ex) {
+        return ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, ex.getMessage());
+    }
+
+    @ExceptionHandler({ActionRoundClosedException.class, DuplicateSubmissionException.class})
+    ProblemDetail handleConflict(RuntimeException ex) {
+        return ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, ex.getMessage());
+    }
+
+    @ExceptionHandler({
+        CardNotInHandException.class,
+        FactionRequiredException.class,
+        JammedPlayerException.class,
+        InvalidActionTargetException.class
+    })
+    ProblemDetail handleUnprocessable(RuntimeException ex) {
+        return ProblemDetail.forStatusAndDetail(HttpStatus.UNPROCESSABLE_CONTENT, ex.getMessage());
+    }
+}

--- a/src/main/resources/openapi/action.yml
+++ b/src/main/resources/openapi/action.yml
@@ -14,7 +14,7 @@ tags:
   - name: Action
 
 paths:
-  /games/{gameId}/rounds/{roundNumber}/actions:
+  /games/{gameId}/eras/{eraNumber}/rounds/{roundNumber}/actions:
     post:
       tags: [ Action ]
       operationId: submitAction
@@ -25,6 +25,12 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: eraNumber
+          in: path
+          required: true
+          schema:
+            type: integer
+            minimum: 1
         - name: roundNumber
           in: path
           required: true
@@ -56,53 +62,13 @@ paths:
             Validation error:
             - Card not in hand (`code: 422-01`)
             - Player jammed (`code: 422-02`)
-            - Round number mismatch (`code: 422-03`)
-            - Invalid target (`code: 422-04`)
+            - Invalid target (`code: 422-03`)
           content:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
 
-  /games/{gameId}/paradox-resolution/actions:
-    post:
-      tags: [ Action ]
-      operationId: submitParadoxResolutionAction
-      parameters:
-        - name: gameId
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SubmitParadoxResolutionActionRequest'
-      responses:
-        '202':
-          description: Action submitted
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SubmitActionResponse'
-        '409':
-          description: |
-            Not in paradox resolution phase (`code: 409-03`) or player already submitted (`code: 409-02`).
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/ProblemDetail'
-        '422':
-          description: |
-            Faction specials not allowed during paradox resolution (`code: 422-05`).
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/ProblemDetail'
-
-  /games/{gameId}/rounds/{roundNumber}/status:
+  /games/{gameId}/eras/{eraNumber}/rounds/{roundNumber}/status:
     get:
       tags: [ Action ]
       operationId: getRoundStatus
@@ -113,6 +79,12 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: eraNumber
+          in: path
+          required: true
+          schema:
+            type: integer
+            minimum: 1
         - name: roundNumber
           in: path
           required: true
@@ -224,34 +196,34 @@ components:
               type: string
               format: uuid
 
-    SubmitParadoxResolutionActionRequest:
-      type: object
-      required: [ cardInstanceId, targetEventId, targetOutcomeId ]
-      properties:
-        cardInstanceId:
-          type: string
-          format: uuid
-        targetEventId:
-          type: string
-          format: uuid
-        targetOutcomeId:
-          type: string
-          format: uuid
-
     SubmitActionResponse:
       type: object
-      required: [ actionId, status ]
+      required: [ gameId, eraNumber, roundNumber, playerId, status, roundClosed ]
       properties:
-        actionId:
+        gameId:
+          type: string
+          format: uuid
+        eraNumber:
+          type: integer
+          minimum: 1
+        roundNumber:
+          type: integer
+          minimum: 1
+        playerId:
           type: string
           format: uuid
         status:
           $ref: '#/components/schemas/ActionSubmissionStatus'
+        roundClosed:
+          type: boolean
 
     RoundStatusResponse:
       type: object
-      required: [ roundNumber, status, timerRemainingSeconds, submittedCount, totalPlayers, pendingPlayerIds ]
+      required: [ eraNumber, roundNumber, status, timerRemainingSeconds, submittedCount, totalPlayers, pendingPlayerIds ]
       properties:
+        eraNumber:
+          type: integer
+          minimum: 1
         roundNumber:
           type: integer
           minimum: 1

--- a/src/test/java/io/github/temporalrift/game/action/application/command/PlayCardCommandHandlerTest.java
+++ b/src/test/java/io/github/temporalrift/game/action/application/command/PlayCardCommandHandlerTest.java
@@ -70,15 +70,7 @@ class PlayCardCommandHandlerTest {
         // given
         var cardInstanceId = UUID.randomUUID();
         var command = new PlayCardUseCase.Command(
-                GAME_ID,
-                ERA,
-                ROUND,
-                PLAYER_ID,
-                cardInstanceId,
-                CardType.PUSH,
-                UUID.randomUUID(),
-                null,
-                UUID.randomUUID());
+                GAME_ID, ERA, ROUND, PLAYER_ID, cardInstanceId, UUID.randomUUID(), null, UUID.randomUUID());
         given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
                 .willReturn(Optional.of(round));
         given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.of(playerState));
@@ -109,8 +101,7 @@ class PlayCardCommandHandlerTest {
     void handleAllSubmittedDoesNotCloseDirectly() {
         // given
         var cardInstanceId = UUID.randomUUID();
-        var command = new PlayCardUseCase.Command(
-                GAME_ID, ERA, ROUND, PLAYER_ID, cardInstanceId, CardType.PUSH, null, null, null);
+        var command = new PlayCardUseCase.Command(GAME_ID, ERA, ROUND, PLAYER_ID, cardInstanceId, null, null, null);
         given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
                 .willReturn(Optional.of(round));
         given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.of(playerState));
@@ -135,8 +126,7 @@ class PlayCardCommandHandlerTest {
         // given
         given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
                 .willReturn(Optional.empty());
-        var command = new PlayCardUseCase.Command(
-                GAME_ID, ERA, ROUND, PLAYER_ID, UUID.randomUUID(), CardType.PUSH, null, null, null);
+        var command = new PlayCardUseCase.Command(GAME_ID, ERA, ROUND, PLAYER_ID, UUID.randomUUID(), null, null, null);
 
         // when / then
         assertThatExceptionOfType(RoundNotFoundException.class).isThrownBy(() -> handler.handle(command));
@@ -149,8 +139,7 @@ class PlayCardCommandHandlerTest {
         given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
                 .willReturn(Optional.of(round));
         given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.empty());
-        var command = new PlayCardUseCase.Command(
-                GAME_ID, ERA, ROUND, PLAYER_ID, UUID.randomUUID(), CardType.PUSH, null, null, null);
+        var command = new PlayCardUseCase.Command(GAME_ID, ERA, ROUND, PLAYER_ID, UUID.randomUUID(), null, null, null);
 
         // when / then
         assertThatExceptionOfType(PlayerStateNotFoundException.class).isThrownBy(() -> handler.handle(command));
@@ -167,8 +156,7 @@ class PlayCardCommandHandlerTest {
         willThrow(new ActionRoundClosedException())
                 .given(round)
                 .submitCard(any(), any(), any(), any(), any(), any(), anyList());
-        var command = new PlayCardUseCase.Command(
-                GAME_ID, ERA, ROUND, PLAYER_ID, CARD_INSTANCE_ID, CardType.PUSH, null, null, null);
+        var command = new PlayCardUseCase.Command(GAME_ID, ERA, ROUND, PLAYER_ID, CARD_INSTANCE_ID, null, null, null);
 
         // when / then
         assertThatExceptionOfType(ActionRoundClosedException.class).isThrownBy(() -> handler.handle(command));
@@ -182,14 +170,11 @@ class PlayCardCommandHandlerTest {
                 .willReturn(Optional.of(round));
         given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.of(playerState));
         given(playerState.hand()).willReturn(List.of());
-        willThrow(new CardNotInHandException(CARD_INSTANCE_ID))
-                .given(round)
-                .submitCard(any(), any(), any(), any(), any(), any(), anyList());
-        var command = new PlayCardUseCase.Command(
-                GAME_ID, ERA, ROUND, PLAYER_ID, CARD_INSTANCE_ID, CardType.PUSH, null, null, null);
+        var command = new PlayCardUseCase.Command(GAME_ID, ERA, ROUND, PLAYER_ID, CARD_INSTANCE_ID, null, null, null);
 
         // when / then
         assertThatExceptionOfType(CardNotInHandException.class).isThrownBy(() -> handler.handle(command));
+        then(round).should(never()).submitCard(any(), any(), any(), any(), any(), any(), anyList());
     }
 
     @Test
@@ -203,8 +188,7 @@ class PlayCardCommandHandlerTest {
         willThrow(new DuplicateSubmissionException(PLAYER_ID))
                 .given(round)
                 .submitCard(any(), any(), any(), any(), any(), any(), anyList());
-        var command = new PlayCardUseCase.Command(
-                GAME_ID, ERA, ROUND, PLAYER_ID, CARD_INSTANCE_ID, CardType.PUSH, null, null, null);
+        var command = new PlayCardUseCase.Command(GAME_ID, ERA, ROUND, PLAYER_ID, CARD_INSTANCE_ID, null, null, null);
 
         // when / then
         assertThatExceptionOfType(DuplicateSubmissionException.class).isThrownBy(() -> handler.handle(command));
@@ -225,8 +209,8 @@ class PlayCardCommandHandlerTest {
         given(round.id()).willReturn(UUID.randomUUID());
         given(round.gameId()).willReturn(GAME_ID);
         given(round.pullEvents()).willReturn(List.of(new Object()));
-        var command = new PlayCardUseCase.Command(
-                GAME_ID, ERA, ROUND, PLAYER_ID, c1.cardInstanceId(), CardType.PUSH, null, null, null);
+        var command =
+                new PlayCardUseCase.Command(GAME_ID, ERA, ROUND, PLAYER_ID, c1.cardInstanceId(), null, null, null);
 
         // when
         handler.handle(command);
@@ -254,15 +238,7 @@ class PlayCardCommandHandlerTest {
         var sourceOutcomeId = UUID.randomUUID();
         var targetOutcomeId = UUID.randomUUID();
         var command = new PlayCardUseCase.Command(
-                GAME_ID,
-                ERA,
-                ROUND,
-                PLAYER_ID,
-                cardInstanceId,
-                CardType.SWING,
-                UUID.randomUUID(),
-                sourceOutcomeId,
-                targetOutcomeId);
+                GAME_ID, ERA, ROUND, PLAYER_ID, cardInstanceId, UUID.randomUUID(), sourceOutcomeId, targetOutcomeId);
         given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
                 .willReturn(Optional.of(round));
         given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.of(playerState));

--- a/src/test/java/io/github/temporalrift/game/action/application/command/PlaySpecialActionCommandHandlerTest.java
+++ b/src/test/java/io/github/temporalrift/game/action/application/command/PlaySpecialActionCommandHandlerTest.java
@@ -28,6 +28,7 @@ import io.github.temporalrift.game.action.application.port.in.PlaySpecialActionU
 import io.github.temporalrift.game.action.domain.actionround.ActionRound;
 import io.github.temporalrift.game.action.domain.actionround.ActionRoundClosedException;
 import io.github.temporalrift.game.action.domain.actionround.DuplicateSubmissionException;
+import io.github.temporalrift.game.action.domain.actionround.FactionRequiredException;
 import io.github.temporalrift.game.action.domain.actionround.JammedPlayerException;
 import io.github.temporalrift.game.action.domain.actionround.RoundNotFoundException;
 import io.github.temporalrift.game.action.domain.playerstate.PlayerState;
@@ -69,18 +70,11 @@ class PlaySpecialActionCommandHandlerTest {
     void handleHappyPath() {
         // given
         var command = new PlaySpecialActionUseCase.Command(
-                GAME_ID,
-                ERA,
-                ROUND,
-                PLAYER_ID,
-                Faction.ERASERS,
-                SpecialAction.ANNIHILATE,
-                UUID.randomUUID(),
-                UUID.randomUUID(),
-                null);
+                GAME_ID, ERA, ROUND, PLAYER_ID, SpecialAction.ANNIHILATE, UUID.randomUUID(), UUID.randomUUID(), null);
         given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
                 .willReturn(Optional.of(round));
         given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.of(playerState));
+        given(playerState.faction()).willReturn(Faction.ERASERS);
         given(playerState.isJammed()).willReturn(false);
         given(round.submitSpecial(any(), any(), any(), any(), any(), any(), anyBoolean()))
                 .willReturn(false);
@@ -108,10 +102,11 @@ class PlaySpecialActionCommandHandlerTest {
     void handleAllSubmittedDoesNotCloseDirectly() {
         // given
         var command = new PlaySpecialActionUseCase.Command(
-                GAME_ID, ERA, ROUND, PLAYER_ID, Faction.PROPHETS, SpecialAction.SEAL, null, null, null);
+                GAME_ID, ERA, ROUND, PLAYER_ID, SpecialAction.SEAL, null, null, null);
         given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
                 .willReturn(Optional.of(round));
         given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.of(playerState));
+        given(playerState.faction()).willReturn(Faction.PROPHETS);
         given(playerState.isJammed()).willReturn(false);
         given(round.submitSpecial(any(), any(), any(), any(), any(), any(), anyBoolean()))
                 .willReturn(true);
@@ -134,7 +129,7 @@ class PlaySpecialActionCommandHandlerTest {
         given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
                 .willReturn(Optional.empty());
         var command = new PlaySpecialActionUseCase.Command(
-                GAME_ID, ERA, ROUND, PLAYER_ID, Faction.PROPHETS, SpecialAction.SEAL, null, null, null);
+                GAME_ID, ERA, ROUND, PLAYER_ID, SpecialAction.SEAL, null, null, null);
 
         // when / then
         assertThatExceptionOfType(RoundNotFoundException.class).isThrownBy(() -> handler.handle(command));
@@ -148,10 +143,28 @@ class PlaySpecialActionCommandHandlerTest {
                 .willReturn(Optional.of(round));
         given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.empty());
         var command = new PlaySpecialActionUseCase.Command(
-                GAME_ID, ERA, ROUND, PLAYER_ID, Faction.PROPHETS, SpecialAction.SEAL, null, null, null);
+                GAME_ID, ERA, ROUND, PLAYER_ID, SpecialAction.SEAL, null, null, null);
 
         // when / then
         assertThatExceptionOfType(PlayerStateNotFoundException.class).isThrownBy(() -> handler.handle(command));
+    }
+
+    @Test
+    @DisplayName("handle — player faction missing — throws FactionRequiredException")
+    void handlePlayerFactionMissing() {
+        // given
+        var command = new PlaySpecialActionUseCase.Command(
+                GAME_ID, ERA, ROUND, PLAYER_ID, SpecialAction.SEAL, null, null, null);
+        given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(round));
+        given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.of(playerState));
+        given(playerState.faction()).willReturn(null);
+
+        // when / then
+        assertThatExceptionOfType(FactionRequiredException.class).isThrownBy(() -> handler.handle(command));
+        then(round).should(never()).submitSpecial(any(), any(), any(), any(), any(), any(), anyBoolean());
+        then(actionRoundRepository).should(never()).save(any());
+        then(actionEventPublisher).shouldHaveNoInteractions();
     }
 
     @Test
@@ -159,10 +172,11 @@ class PlaySpecialActionCommandHandlerTest {
     void handleJammedPlayer() {
         // given
         var command = new PlaySpecialActionUseCase.Command(
-                GAME_ID, ERA, ROUND, PLAYER_ID, Faction.ERASERS, SpecialAction.ANNIHILATE, null, null, null);
+                GAME_ID, ERA, ROUND, PLAYER_ID, SpecialAction.ANNIHILATE, null, null, null);
         given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
                 .willReturn(Optional.of(round));
         given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.of(playerState));
+        given(playerState.faction()).willReturn(Faction.ERASERS);
         given(playerState.isJammed()).willReturn(true);
         willThrow(new JammedPlayerException(PLAYER_ID))
                 .given(round)
@@ -179,12 +193,13 @@ class PlaySpecialActionCommandHandlerTest {
         given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
                 .willReturn(Optional.of(round));
         given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.of(playerState));
+        given(playerState.faction()).willReturn(Faction.PROPHETS);
         given(playerState.isJammed()).willReturn(false);
         willThrow(new ActionRoundClosedException())
                 .given(round)
                 .submitSpecial(any(), any(), any(), any(), any(), any(), anyBoolean());
         var command = new PlaySpecialActionUseCase.Command(
-                GAME_ID, ERA, ROUND, PLAYER_ID, Faction.PROPHETS, SpecialAction.SEAL, null, null, null);
+                GAME_ID, ERA, ROUND, PLAYER_ID, SpecialAction.SEAL, null, null, null);
 
         // when / then
         assertThatExceptionOfType(ActionRoundClosedException.class).isThrownBy(() -> handler.handle(command));
@@ -197,12 +212,13 @@ class PlaySpecialActionCommandHandlerTest {
         given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
                 .willReturn(Optional.of(round));
         given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.of(playerState));
+        given(playerState.faction()).willReturn(Faction.PROPHETS);
         given(playerState.isJammed()).willReturn(false);
         willThrow(new DuplicateSubmissionException(PLAYER_ID))
                 .given(round)
                 .submitSpecial(any(), any(), any(), any(), any(), any(), anyBoolean());
         var command = new PlaySpecialActionUseCase.Command(
-                GAME_ID, ERA, ROUND, PLAYER_ID, Faction.PROPHETS, SpecialAction.SEAL, null, null, null);
+                GAME_ID, ERA, ROUND, PLAYER_ID, SpecialAction.SEAL, null, null, null);
 
         // when / then
         assertThatExceptionOfType(DuplicateSubmissionException.class).isThrownBy(() -> handler.handle(command));
@@ -213,10 +229,11 @@ class PlaySpecialActionCommandHandlerTest {
     void handlePassesIsJammedToAggregate() {
         // given
         var command = new PlaySpecialActionUseCase.Command(
-                GAME_ID, ERA, ROUND, PLAYER_ID, Faction.ERASERS, SpecialAction.CORRUPT, null, null, UUID.randomUUID());
+                GAME_ID, ERA, ROUND, PLAYER_ID, SpecialAction.CORRUPT, null, null, UUID.randomUUID());
         given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
                 .willReturn(Optional.of(round));
         given(playerStateRepository.findByGameIdAndPlayerId(GAME_ID, PLAYER_ID)).willReturn(Optional.of(playerState));
+        given(playerState.faction()).willReturn(Faction.ERASERS);
         given(playerState.isJammed()).willReturn(false);
         given(round.submitSpecial(any(), any(), any(), any(), any(), any(), anyBoolean()))
                 .willReturn(false);

--- a/src/test/java/io/github/temporalrift/game/action/application/query/GetRoundStatusQueryHandlerTest.java
+++ b/src/test/java/io/github/temporalrift/game/action/application/query/GetRoundStatusQueryHandlerTest.java
@@ -1,0 +1,226 @@
+package io.github.temporalrift.game.action.application.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.BDDMockito.given;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.github.temporalrift.events.shared.CardType;
+import io.github.temporalrift.game.action.application.port.in.GetRoundStatusUseCase;
+import io.github.temporalrift.game.action.domain.actionround.ActionRound;
+import io.github.temporalrift.game.action.domain.actionround.RoundNotFoundException;
+import io.github.temporalrift.game.action.domain.actionround.RoundStatus;
+import io.github.temporalrift.game.action.domain.actionround.SubmittedAction;
+import io.github.temporalrift.game.action.domain.port.out.ActionRoundRepository;
+import io.github.temporalrift.game.action.domain.port.out.ActionRoundSagaRepository;
+import io.github.temporalrift.game.action.domain.saga.ActionRoundSagaState;
+import io.github.temporalrift.game.action.domain.saga.ActionRoundSagaStatus;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetRoundStatusQueryHandler")
+class GetRoundStatusQueryHandlerTest {
+
+    static final UUID GAME_ID = UUID.randomUUID();
+    static final int ERA = 2;
+    static final int ROUND = 1;
+    static final Instant NOW = Instant.parse("2026-06-08T10:00:00Z");
+    static final Clock CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    @Mock
+    ActionRoundRepository actionRoundRepository;
+
+    @Mock
+    ActionRoundSagaRepository actionRoundSagaRepository;
+
+    @Mock
+    ActionRound round;
+
+    @Test
+    @DisplayName("handle — open round with saga state — returns public status and remaining timer")
+    void handleOpenRoundWithSagaState() {
+        // given
+        var pendingPlayer = UUID.randomUUID();
+        var submittedAction = submittedAction();
+        given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(round));
+        given(actionRoundSagaRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(sagaState(NOW.plusSeconds(42))));
+        given(round.eraNumber()).willReturn(ERA);
+        given(round.roundNumber()).willReturn(ROUND);
+        given(round.status()).willReturn(RoundStatus.OPEN);
+        given(round.submittedActions()).willReturn(List.of(submittedAction));
+        var sagaState = sagaState(NOW.plusSeconds(42), List.of(pendingPlayer));
+        given(actionRoundSagaRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(sagaState));
+        var handler = new GetRoundStatusQueryHandler(actionRoundRepository, actionRoundSagaRepository, CLOCK);
+
+        // when
+        var result = handler.handle(new GetRoundStatusUseCase.Query(GAME_ID, ERA, ROUND));
+
+        // then
+        assertThat(result.eraNumber()).isEqualTo(ERA);
+        assertThat(result.roundNumber()).isEqualTo(ROUND);
+        assertThat(result.status()).isEqualTo("OPEN");
+        assertThat(result.timerRemainingSeconds()).isEqualTo(42);
+        assertThat(result.submittedCount()).isEqualTo(1);
+        assertThat(result.totalPlayers()).isEqualTo(2);
+        assertThat(result.pendingPlayerIds()).containsExactly(pendingPlayer);
+    }
+
+    @Test
+    @DisplayName("handle — closed timeout round — reports saga pending players after aggregate clears pending")
+    void handleClosedTimeoutRoundReportsSagaPendingPlayers() {
+        // given
+        var skippedPlayer = UUID.randomUUID();
+        var submittedAction = submittedAction();
+        given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(round));
+        given(actionRoundSagaRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(sagaState(NOW.minusSeconds(1), List.of(skippedPlayer))));
+        given(round.eraNumber()).willReturn(ERA);
+        given(round.roundNumber()).willReturn(ROUND);
+        given(round.status()).willReturn(RoundStatus.CLOSED);
+        given(round.submittedActions()).willReturn(List.of(submittedAction));
+        var handler = new GetRoundStatusQueryHandler(actionRoundRepository, actionRoundSagaRepository, CLOCK);
+
+        // when
+        var result = handler.handle(new GetRoundStatusUseCase.Query(GAME_ID, ERA, ROUND));
+
+        // then
+        assertThat(result.status()).isEqualTo("CLOSED");
+        assertThat(result.submittedCount()).isEqualTo(1);
+        assertThat(result.totalPlayers()).isEqualTo(2);
+        assertThat(result.pendingPlayerIds()).containsExactly(skippedPlayer);
+    }
+
+    @Test
+    @DisplayName("handle — closed round — maps status to CLOSED")
+    void handleClosedRound() {
+        // given
+        given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(round));
+        given(actionRoundSagaRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(sagaState(NOW.plusSeconds(5))));
+        given(round.eraNumber()).willReturn(ERA);
+        given(round.roundNumber()).willReturn(ROUND);
+        given(round.status()).willReturn(RoundStatus.CLOSED);
+        given(round.submittedActions()).willReturn(List.of());
+        var handler = new GetRoundStatusQueryHandler(actionRoundRepository, actionRoundSagaRepository, CLOCK);
+
+        // when
+        var result = handler.handle(new GetRoundStatusUseCase.Query(GAME_ID, ERA, ROUND));
+
+        // then
+        assertThat(result.status()).isEqualTo("CLOSED");
+    }
+
+    @Test
+    @DisplayName("handle — expired timer — clamps remaining seconds to zero")
+    void handleExpiredTimer() {
+        // given
+        given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(round));
+        given(actionRoundSagaRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(sagaState(NOW.minusSeconds(1))));
+        given(round.eraNumber()).willReturn(ERA);
+        given(round.roundNumber()).willReturn(ROUND);
+        given(round.status()).willReturn(RoundStatus.OPEN);
+        given(round.submittedActions()).willReturn(List.of());
+        var handler = new GetRoundStatusQueryHandler(actionRoundRepository, actionRoundSagaRepository, CLOCK);
+
+        // when
+        var result = handler.handle(new GetRoundStatusUseCase.Query(GAME_ID, ERA, ROUND));
+
+        // then
+        assertThat(result.timerRemainingSeconds()).isZero();
+    }
+
+    @Test
+    @DisplayName("handle — very long timer — clamps remaining seconds to max int")
+    void handleVeryLongTimerClampsToMaxInt() {
+        // given
+        given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(round));
+        given(actionRoundSagaRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(sagaState(NOW.plusSeconds((long) Integer.MAX_VALUE + 1), List.of())));
+        given(round.eraNumber()).willReturn(ERA);
+        given(round.roundNumber()).willReturn(ROUND);
+        given(round.status()).willReturn(RoundStatus.OPEN);
+        given(round.submittedActions()).willReturn(List.of());
+        var handler = new GetRoundStatusQueryHandler(actionRoundRepository, actionRoundSagaRepository, CLOCK);
+
+        // when
+        var result = handler.handle(new GetRoundStatusUseCase.Query(GAME_ID, ERA, ROUND));
+
+        // then
+        assertThat(result.timerRemainingSeconds()).isEqualTo(Integer.MAX_VALUE);
+    }
+
+    @Test
+    @DisplayName("handle — saga state missing — returns timer zero")
+    void handleSagaStateMissing() {
+        // given
+        given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.of(round));
+        given(actionRoundSagaRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.empty());
+        given(round.eraNumber()).willReturn(ERA);
+        given(round.roundNumber()).willReturn(ROUND);
+        given(round.status()).willReturn(RoundStatus.CLOSING);
+        given(round.pendingPlayerIds()).willReturn(List.of());
+        given(round.submittedActions()).willReturn(List.of());
+        var handler = new GetRoundStatusQueryHandler(actionRoundRepository, actionRoundSagaRepository, CLOCK);
+
+        // when
+        var result = handler.handle(new GetRoundStatusUseCase.Query(GAME_ID, ERA, ROUND));
+
+        // then
+        assertThat(result.status()).isEqualTo("CLOSED");
+        assertThat(result.timerRemainingSeconds()).isZero();
+    }
+
+    @Test
+    @DisplayName("handle — round missing — throws RoundNotFoundException")
+    void handleRoundMissing() {
+        // given
+        given(actionRoundRepository.findByGameIdAndEraNumberAndRoundNumber(GAME_ID, ERA, ROUND))
+                .willReturn(Optional.empty());
+        var handler = new GetRoundStatusQueryHandler(actionRoundRepository, actionRoundSagaRepository, CLOCK);
+        var query = new GetRoundStatusUseCase.Query(GAME_ID, ERA, ROUND);
+
+        // when / then
+        assertThatExceptionOfType(RoundNotFoundException.class).isThrownBy(() -> handler.handle(query));
+    }
+
+    private static ActionRoundSagaState sagaState(Instant timerExpiresAt) {
+        return sagaState(timerExpiresAt, List.of(UUID.randomUUID()));
+    }
+
+    private static ActionRoundSagaState sagaState(Instant timerExpiresAt, List<UUID> pendingPlayerIds) {
+        return new ActionRoundSagaState(
+                UUID.randomUUID(),
+                GAME_ID,
+                ERA,
+                ROUND,
+                ActionRoundSagaStatus.WAITING,
+                pendingPlayerIds,
+                timerExpiresAt);
+    }
+
+    private static SubmittedAction submittedAction() {
+        return new SubmittedAction.CardAction(
+                UUID.randomUUID(), UUID.randomUUID(), CardType.PUSH, UUID.randomUUID(), null, UUID.randomUUID());
+    }
+}

--- a/src/test/java/io/github/temporalrift/game/action/domain/actionround/ActionRoundTest.java
+++ b/src/test/java/io/github/temporalrift/game/action/domain/actionround/ActionRoundTest.java
@@ -264,6 +264,22 @@ class ActionRoundTest {
     }
 
     @Test
+    @DisplayName("submitSpecial — missing faction — throws FactionRequiredException")
+    void submitSpecialMissingFactionThrows() {
+        // given
+        var round = openRound(List.of(PLAYER_A));
+        round.pullEvents();
+
+        // when / then
+        assertThatExceptionOfType(FactionRequiredException.class)
+                .isThrownBy(
+                        () -> round.submitSpecial(PLAYER_A, null, SpecialAction.ANNIHILATE, null, null, null, false));
+        assertThat(round.pendingPlayerIds()).containsExactly(PLAYER_A);
+        assertThat(round.submittedActions()).isEmpty();
+        assertThat(round.pullEvents()).isEmpty();
+    }
+
+    @Test
     @DisplayName("submitSpecial — round is CLOSED — throws ActionRoundClosedException")
     void submitSpecialOnClosedRoundThrows() {
         // given

--- a/src/test/java/io/github/temporalrift/game/action/infrastructure/adapter/in/rest/ActionControllerTest.java
+++ b/src/test/java/io/github/temporalrift/game/action/infrastructure/adapter/in/rest/ActionControllerTest.java
@@ -1,0 +1,289 @@
+package io.github.temporalrift.game.action.infrastructure.adapter.in.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import io.github.temporalrift.game.TestSecurityConfig;
+import io.github.temporalrift.game.action.application.port.in.GetRoundStatusUseCase;
+import io.github.temporalrift.game.action.application.port.in.PlayCardUseCase;
+import io.github.temporalrift.game.action.application.port.in.PlaySpecialActionUseCase;
+import io.github.temporalrift.game.action.domain.CardNotInHandException;
+import io.github.temporalrift.game.action.domain.actionround.ActionRoundClosedException;
+import io.github.temporalrift.game.action.domain.actionround.DuplicateSubmissionException;
+import io.github.temporalrift.game.action.domain.actionround.FactionRequiredException;
+import io.github.temporalrift.game.action.domain.actionround.InvalidActionTargetException;
+import io.github.temporalrift.game.action.domain.actionround.JammedPlayerException;
+import io.github.temporalrift.game.action.domain.actionround.RoundNotFoundException;
+import io.github.temporalrift.game.shared.PlayerPrincipal;
+import io.github.temporalrift.game.shared.infrastructure.config.PlayerAuthenticationToken;
+import io.github.temporalrift.game.shared.infrastructure.config.SecurityConfig;
+
+@WebMvcTest(ActionController.class)
+@Import({SecurityConfig.class, TestSecurityConfig.class})
+class ActionControllerTest {
+
+    static final UUID PLAYER_ID = UUID.randomUUID();
+    static final UUID GAME_ID = UUID.randomUUID();
+    static final UUID CARD_INSTANCE_ID = UUID.randomUUID();
+    static final UUID TARGET_EVENT_ID = UUID.randomUUID();
+    static final UUID SOURCE_OUTCOME_ID = UUID.randomUUID();
+    static final UUID TARGET_OUTCOME_ID = UUID.randomUUID();
+    static final UUID TARGET_PLAYER_ID = UUID.randomUUID();
+    static final int ERA = 2;
+    static final int ROUND = 3;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    PlayCardUseCase playCardUseCase;
+
+    @MockitoBean
+    PlaySpecialActionUseCase playSpecialActionUseCase;
+
+    @MockitoBean
+    GetRoundStatusUseCase getRoundStatusUseCase;
+
+    private RequestPostProcessor auth() {
+        return authentication(new PlayerAuthenticationToken(new PlayerPrincipal(PLAYER_ID)));
+    }
+
+    @Test
+    @DisplayName("Given no JWT, when POST action, then 401")
+    void submitActionNoJwt() throws Exception {
+        mockMvc.perform(post("/games/{gameId}/eras/{eraNumber}/rounds/{roundNumber}/actions", GAME_ID, ERA, ROUND)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(cardJson()))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Given CARD request, when POST action, then dispatches authenticated command and returns 202")
+    void submitCard() throws Exception {
+        // given
+        given(playCardUseCase.handle(any()))
+                .willReturn(new PlayCardUseCase.Result(GAME_ID, ERA, ROUND, PLAYER_ID, false));
+
+        // when / then
+        mockMvc.perform(post("/games/{gameId}/eras/{eraNumber}/rounds/{roundNumber}/actions", GAME_ID, ERA, ROUND)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(cardJson()))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.gameId").value(GAME_ID.toString()))
+                .andExpect(jsonPath("$.eraNumber").value(ERA))
+                .andExpect(jsonPath("$.roundNumber").value(ROUND))
+                .andExpect(jsonPath("$.playerId").value(PLAYER_ID.toString()))
+                .andExpect(jsonPath("$.status").value("SUBMITTED"))
+                .andExpect(jsonPath("$.roundClosed").value(false));
+
+        var captor = ArgumentCaptor.forClass(PlayCardUseCase.Command.class);
+        org.mockito.BDDMockito.then(playCardUseCase).should().handle(captor.capture());
+        assertThat(captor.getValue().gameId()).isEqualTo(GAME_ID);
+        assertThat(captor.getValue().eraNumber()).isEqualTo(ERA);
+        assertThat(captor.getValue().roundNumber()).isEqualTo(ROUND);
+        assertThat(captor.getValue().playerId()).isEqualTo(PLAYER_ID);
+        assertThat(captor.getValue().cardInstanceId()).isEqualTo(CARD_INSTANCE_ID);
+        assertThat(captor.getValue().targetEventId()).isEqualTo(TARGET_EVENT_ID);
+        assertThat(captor.getValue().sourceOutcomeId()).isEqualTo(SOURCE_OUTCOME_ID);
+        assertThat(captor.getValue().targetOutcomeId()).isEqualTo(TARGET_OUTCOME_ID);
+    }
+
+    @Test
+    @DisplayName("Given SPECIAL request, when POST action, then maps generated enum and returns 202")
+    void submitSpecial() throws Exception {
+        // given
+        given(playSpecialActionUseCase.handle(any()))
+                .willReturn(new PlaySpecialActionUseCase.Result(GAME_ID, ERA, ROUND, PLAYER_ID, true));
+
+        // when / then
+        mockMvc.perform(post("/games/{gameId}/eras/{eraNumber}/rounds/{roundNumber}/actions", GAME_ID, ERA, ROUND)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(specialJson()))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.roundClosed").value(true));
+
+        var captor = ArgumentCaptor.forClass(PlaySpecialActionUseCase.Command.class);
+        org.mockito.BDDMockito.then(playSpecialActionUseCase).should().handle(captor.capture());
+        assertThat(captor.getValue().gameId()).isEqualTo(GAME_ID);
+        assertThat(captor.getValue().eraNumber()).isEqualTo(ERA);
+        assertThat(captor.getValue().roundNumber()).isEqualTo(ROUND);
+        assertThat(captor.getValue().playerId()).isEqualTo(PLAYER_ID);
+        assertThat(captor.getValue().specialAction())
+                .isEqualTo(io.github.temporalrift.events.shared.SpecialAction.CORRUPT);
+        assertThat(captor.getValue().targetEventId()).isEqualTo(TARGET_EVENT_ID);
+        assertThat(captor.getValue().targetOutcomeId()).isEqualTo(TARGET_OUTCOME_ID);
+        assertThat(captor.getValue().targetPlayerId()).isEqualTo(TARGET_PLAYER_ID);
+    }
+
+    @Test
+    @DisplayName("Given no JWT, when GET status, then 401")
+    void getRoundStatusNoJwt() throws Exception {
+        mockMvc.perform(get("/games/{gameId}/eras/{eraNumber}/rounds/{roundNumber}/status", GAME_ID, ERA, ROUND))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Given round status, when GET status, then returns public status")
+    void getRoundStatus() throws Exception {
+        // given
+        var pendingPlayerId = UUID.randomUUID();
+        given(getRoundStatusUseCase.handle(any()))
+                .willReturn(new GetRoundStatusUseCase.Result(ERA, ROUND, "OPEN", 42, 2, 3, List.of(pendingPlayerId)));
+
+        // when / then
+        mockMvc.perform(get("/games/{gameId}/eras/{eraNumber}/rounds/{roundNumber}/status", GAME_ID, ERA, ROUND)
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.eraNumber").value(ERA))
+                .andExpect(jsonPath("$.roundNumber").value(ROUND))
+                .andExpect(jsonPath("$.status").value("OPEN"))
+                .andExpect(jsonPath("$.timerRemainingSeconds").value(42))
+                .andExpect(jsonPath("$.submittedCount").value(2))
+                .andExpect(jsonPath("$.totalPlayers").value(3))
+                .andExpect(jsonPath("$.pendingPlayerIds[0]").value(pendingPlayerId.toString()));
+    }
+
+    @Test
+    @DisplayName("Given RoundNotFoundException, then returns 404")
+    void roundNotFound() throws Exception {
+        // given
+        given(getRoundStatusUseCase.handle(any())).willThrow(new RoundNotFoundException(GAME_ID, ERA, ROUND));
+
+        // when / then
+        mockMvc.perform(get("/games/{gameId}/eras/{eraNumber}/rounds/{roundNumber}/status", GAME_ID, ERA, ROUND)
+                        .with(auth()))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Given ActionRoundClosedException, then returns 409")
+    void actionRoundClosed() throws Exception {
+        // given
+        given(playCardUseCase.handle(any())).willThrow(new ActionRoundClosedException());
+
+        // when / then
+        mockMvc.perform(post("/games/{gameId}/eras/{eraNumber}/rounds/{roundNumber}/actions", GAME_ID, ERA, ROUND)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(cardJson()))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("Given DuplicateSubmissionException, then returns 409")
+    void duplicateSubmission() throws Exception {
+        // given
+        given(playCardUseCase.handle(any())).willThrow(new DuplicateSubmissionException(PLAYER_ID));
+
+        // when / then
+        mockMvc.perform(post("/games/{gameId}/eras/{eraNumber}/rounds/{roundNumber}/actions", GAME_ID, ERA, ROUND)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(cardJson()))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("Given CardNotInHandException, then returns 422")
+    void cardNotInHand() throws Exception {
+        // given
+        given(playCardUseCase.handle(any())).willThrow(new CardNotInHandException(CARD_INSTANCE_ID));
+
+        // when / then
+        mockMvc.perform(post("/games/{gameId}/eras/{eraNumber}/rounds/{roundNumber}/actions", GAME_ID, ERA, ROUND)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(cardJson()))
+                .andExpect(status().is(422));
+    }
+
+    @Test
+    @DisplayName("Given JammedPlayerException, then returns 422")
+    void jammedPlayer() throws Exception {
+        // given
+        given(playSpecialActionUseCase.handle(any())).willThrow(new JammedPlayerException(PLAYER_ID));
+
+        // when / then
+        mockMvc.perform(post("/games/{gameId}/eras/{eraNumber}/rounds/{roundNumber}/actions", GAME_ID, ERA, ROUND)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(specialJson()))
+                .andExpect(status().is(422));
+    }
+
+    @Test
+    @DisplayName("Given FactionRequiredException, then returns 422")
+    void factionRequired() throws Exception {
+        // given
+        given(playSpecialActionUseCase.handle(any())).willThrow(new FactionRequiredException(PLAYER_ID));
+
+        // when / then
+        mockMvc.perform(post("/games/{gameId}/eras/{eraNumber}/rounds/{roundNumber}/actions", GAME_ID, ERA, ROUND)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(specialJson()))
+                .andExpect(status().is(422));
+    }
+
+    @Test
+    @DisplayName("Given InvalidActionTargetException, then returns 422")
+    void invalidActionTarget() throws Exception {
+        // given
+        given(playCardUseCase.handle(any()))
+                .willThrow(new InvalidActionTargetException(
+                        io.github.temporalrift.events.shared.CardType.SWING, SOURCE_OUTCOME_ID, SOURCE_OUTCOME_ID));
+
+        // when / then
+        mockMvc.perform(post("/games/{gameId}/eras/{eraNumber}/rounds/{roundNumber}/actions", GAME_ID, ERA, ROUND)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(cardJson()))
+                .andExpect(status().is(422));
+    }
+
+    private static String cardJson() {
+        return """
+                {
+                  "actionType": "CARD",
+                  "cardInstanceId": "%s",
+                  "targetEventId": "%s",
+                  "sourceOutcomeId": "%s",
+                  "targetOutcomeId": "%s"
+                }
+                """.formatted(CARD_INSTANCE_ID, TARGET_EVENT_ID, SOURCE_OUTCOME_ID, TARGET_OUTCOME_ID);
+    }
+
+    private static String specialJson() {
+        return """
+                {
+                  "actionType": "SPECIAL",
+                  "specialAction": "CORRUPT",
+                  "targetEventId": "%s",
+                  "targetOutcomeId": "%s",
+                  "targetPlayerId": "%s"
+                }
+                """.formatted(TARGET_EVENT_ID, TARGET_OUTCOME_ID, TARGET_PLAYER_ID);
+    }
+}


### PR DESCRIPTION
## Summary

- Add era-scoped normal action submission and round status endpoints.
- Derive submitted card type from persisted player hand and reject special actions when the player has no assigned faction.
- Add round-status query handling that exposes submission progress without revealing submitted actions, including timeout-closed pending players from saga state.
- Defer paradox-resolution REST exposure until a real use case exists.

## Validation

- `mvn -Dtest=ActionRoundTest,PlaySpecialActionCommandHandlerTest,GetRoundStatusQueryHandlerTest,ActionControllerTest test`
- `mvn -Dtest=GameServiceApplicationIT test`
- `mvn validate`

Closes #31