### PR TITLE
test(action): add module architecture checks

### DIFF
--- a/src/test/java/io/github/temporalrift/game/GameServiceApplicationIT.java
+++ b/src/test/java/io/github/temporalrift/game/GameServiceApplicationIT.java
@@ -1,5 +1,7 @@
 package io.github.temporalrift.game;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
@@ -17,6 +19,9 @@ class GameServiceApplicationIT {
         var modules = ApplicationModules.of(GameServiceApplication.class);
 
         modules.verify();
+        assertThat(modules.getModuleByName("action"))
+                .as("action module must be detected by Spring Modulith")
+                .isPresent();
 
         new Documenter(modules)
                 .writeModulesAsPlantUml(DiagramOptions.defaults())

--- a/src/test/java/io/github/temporalrift/game/action/ActionModuleArchitectureTest.java
+++ b/src/test/java/io/github/temporalrift/game/action/ActionModuleArchitectureTest.java
@@ -121,10 +121,13 @@ public class ActionModuleArchitectureTest {
                     "io.github.temporalrift.game.action.domain..", "io.github.temporalrift.game.action.application..")
             .should()
             .dependOnClassesThat()
-            .resideInAnyPackage(
-                    "io.github.temporalrift.game.session.infrastructure.adapter.out.config..",
-                    "org.springframework.beans.factory.annotation.Value",
-                    "org.springframework.boot.context.properties..")
+            .resideInAnyPackage("io.github.temporalrift.game.session.infrastructure.adapter.out.config..")
+            .orShould()
+            .dependOnClassesThat()
+            .haveFullyQualifiedName("org.springframework.beans.factory.annotation.Value")
+            .orShould()
+            .dependOnClassesThat()
+            .resideInAnyPackage("org.springframework.boot.context.properties..")
             .as("Action domain/application code must access configuration through ports such as GameRulesPort");
 
     private static ArchCondition<JavaMethod> notAcceptEventEnvelope() {

--- a/src/test/java/io/github/temporalrift/game/action/ActionModuleArchitectureTest.java
+++ b/src/test/java/io/github/temporalrift/game/action/ActionModuleArchitectureTest.java
@@ -1,0 +1,165 @@
+package io.github.temporalrift.game.action;
+
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.modulith.events.ApplicationModuleListener;
+
+import io.github.temporalrift.events.envelope.EventEnvelope;
+
+@AnalyzeClasses(packages = "io.github.temporalrift.game.action", importOptions = ImportOption.DoNotIncludeTests.class)
+public class ActionModuleArchitectureTest {
+
+    @ArchTest
+    static final ArchRule domain_must_not_depend_on_spring_or_persistence = noClasses()
+            .that()
+            .resideInAPackage("io.github.temporalrift.game.action.domain..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAnyPackage("org.springframework..", "jakarta.persistence..", "lombok..")
+            .as("Action domain layer must be plain Java — no Spring, JPA, or Lombok");
+
+    @ArchTest
+    static final ArchRule application_must_not_depend_on_infrastructure = noClasses()
+            .that()
+            .resideInAPackage("io.github.temporalrift.game.action.application..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage("io.github.temporalrift.game.action.infrastructure..")
+            .as("Action application layer must not depend on infrastructure");
+
+    @ArchTest
+    static final ArchRule driven_ports_must_only_be_implemented_in_infrastructure = noClasses()
+            .that()
+            .resideOutsideOfPackage("io.github.temporalrift.game.action.infrastructure.adapter.out..")
+            .should()
+            .implement(resideInAPackage("io.github.temporalrift.game.action.domain.port.out.."))
+            .as("Driven ports must only be implemented in action infrastructure.adapter.out");
+
+    @ArchTest
+    static final ArchRule action_must_not_use_field_injection = noFields()
+            .that()
+            .areDeclaredInClassesThat()
+            .resideInAPackage("io.github.temporalrift.game.action..")
+            .should()
+            .beAnnotatedWith(Autowired.class)
+            .as("Action module must use constructor injection — never @Autowired on fields");
+
+    @ArchTest
+    static final ArchRule no_cross_module_internal_dependency = noClasses()
+            .that()
+            .resideInAPackage("io.github.temporalrift.game.action..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAnyPackage(
+                    "io.github.temporalrift.game.session.application..",
+                    "io.github.temporalrift.game.session.domain..",
+                    "io.github.temporalrift.game.session.infrastructure..",
+                    "io.github.temporalrift.game.scoring.application..",
+                    "io.github.temporalrift.game.scoring.domain..",
+                    "io.github.temporalrift.game.scoring.infrastructure..",
+                    "io.github.temporalrift.game.shared.infrastructure..")
+            .as("Action module must not depend on session, scoring, or shared internals — use published API only");
+
+    @ArchTest
+    static final ArchRule no_bare_event_listener_annotations = methods()
+            .that()
+            .areDeclaredInClassesThat()
+            .resideInAPackage("io.github.temporalrift.game.action..")
+            .should(notUseBareEventListener())
+            .as("Action module must use @ApplicationModuleListener — never bare @EventListener");
+
+    @ArchTest
+    static final ArchRule spring_event_listeners_must_not_receive_event_envelopes = methods()
+            .that()
+            .areDeclaredInClassesThat()
+            .resideInAPackage("io.github.temporalrift.game.action..")
+            .and()
+            .areAnnotatedWith(ApplicationModuleListener.class)
+            .should(notAcceptEventEnvelope())
+            .as("Action Spring event listeners must subscribe to typed payload events, never EventEnvelope");
+
+    @ArchTest
+    static final ArchRule action_must_not_publish_directly_to_kafka = noClasses()
+            .that()
+            .resideInAPackage("io.github.temporalrift.game.action..")
+            .should()
+            .dependOnClassesThat()
+            .areAssignableTo(KafkaTemplate.class)
+            .as("Action module must publish through ActionEventPublisher, not KafkaTemplate");
+
+    @ArchTest
+    static final ArchRule rest_adapters_must_not_depend_on_concrete_application_implementations = noClasses()
+            .that()
+            .resideInAPackage("io.github.temporalrift.game.action.infrastructure.adapter.in.rest..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAnyPackage(
+                    "io.github.temporalrift.game.action.application.command..",
+                    "io.github.temporalrift.game.action.application.query..",
+                    "io.github.temporalrift.game.action.application.saga..")
+            .as("Action REST adapters must depend on application.port.in use cases, not concrete handlers or sagas");
+
+    @ArchTest
+    static final ArchRule action_domain_and_application_must_not_depend_on_configuration_properties = noClasses()
+            .that()
+            .resideInAnyPackage(
+                    "io.github.temporalrift.game.action.domain..", "io.github.temporalrift.game.action.application..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAnyPackage(
+                    "io.github.temporalrift.game.session.infrastructure.adapter.out.config..",
+                    "org.springframework.beans.factory.annotation.Value",
+                    "org.springframework.boot.context.properties..")
+            .as("Action domain/application code must access configuration through ports such as GameRulesPort");
+
+    private static ArchCondition<JavaMethod> notAcceptEventEnvelope() {
+        return new ArchCondition<>("not declare EventEnvelope as a listener parameter") {
+            @Override
+            public void check(JavaMethod method, ConditionEvents events) {
+                var hasEventEnvelopeParameter = method.getRawParameterTypes().stream()
+                        .map(JavaClass::reflect)
+                        .anyMatch(EventEnvelope.class::equals);
+
+                if (hasEventEnvelopeParameter) {
+                    events.add(SimpleConditionEvent.violated(
+                            method, method.getFullName() + " must not declare EventEnvelope as a listener parameter"));
+                }
+            }
+        };
+    }
+
+    private static ArchCondition<JavaMethod> notUseBareEventListener() {
+        return new ArchCondition<>("not use bare @EventListener") {
+            @Override
+            public void check(JavaMethod method, ConditionEvents events) {
+                var annotationTypeNames = method.getAnnotations().stream()
+                        .map(annotation -> annotation.getRawType().getName())
+                        .toList();
+
+                var hasBareEventListener = annotationTypeNames.contains(EventListener.class.getName())
+                        && !annotationTypeNames.contains(ApplicationModuleListener.class.getName());
+
+                if (hasBareEventListener) {
+                    events.add(SimpleConditionEvent.violated(
+                            method,
+                            method.getFullName() + " must use @ApplicationModuleListener instead of @EventListener"));
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add an action-scoped ArchUnit test suite for module boundaries, listener conventions, Kafka publishing, and REST adapter dependencies
- assert in GameServiceApplicationIT that Spring Modulith detects the ction module explicitly

## Validation
- attempted mvn -f D:\code\temporal-rift\game-service\pom.xml test -Dtest=ArchitectureTest,ActionModuleArchitectureTest
- build is currently blocked by an existing unrelated 	estCompile failure in CardActionRequestTest for missing generated classes under 	arget/classes
