### PR TITLE
feat: add player score aggregate

### DIFF
--- a/src/main/java/io/github/temporalrift/game/scoring/domain/playerscore/InvalidScoreEraException.java
+++ b/src/main/java/io/github/temporalrift/game/scoring/domain/playerscore/InvalidScoreEraException.java
@@ -1,0 +1,8 @@
+package io.github.temporalrift.game.scoring.domain.playerscore;
+
+public class InvalidScoreEraException extends RuntimeException {
+
+    public InvalidScoreEraException(int eraNumber) {
+        super("Score era number must be positive: " + eraNumber);
+    }
+}

--- a/src/main/java/io/github/temporalrift/game/scoring/domain/playerscore/InvalidScoreReasonException.java
+++ b/src/main/java/io/github/temporalrift/game/scoring/domain/playerscore/InvalidScoreReasonException.java
@@ -1,0 +1,10 @@
+package io.github.temporalrift.game.scoring.domain.playerscore;
+
+import io.github.temporalrift.events.shared.Faction;
+
+public class InvalidScoreReasonException extends RuntimeException {
+
+    public InvalidScoreReasonException(Faction playerFaction, ScoreReason reason) {
+        super("Score reason %s belongs to %s, not %s".formatted(reason, reason.faction(), playerFaction));
+    }
+}

--- a/src/main/java/io/github/temporalrift/game/scoring/domain/playerscore/InvalidWinScoreThresholdException.java
+++ b/src/main/java/io/github/temporalrift/game/scoring/domain/playerscore/InvalidWinScoreThresholdException.java
@@ -1,8 +1,0 @@
-package io.github.temporalrift.game.scoring.domain.playerscore;
-
-public class InvalidWinScoreThresholdException extends RuntimeException {
-
-    public InvalidWinScoreThresholdException(int winScoreThreshold) {
-        super("Win score threshold must be positive: " + winScoreThreshold);
-    }
-}

--- a/src/main/java/io/github/temporalrift/game/scoring/domain/playerscore/InvalidWinScoreThresholdException.java
+++ b/src/main/java/io/github/temporalrift/game/scoring/domain/playerscore/InvalidWinScoreThresholdException.java
@@ -1,0 +1,8 @@
+package io.github.temporalrift.game.scoring.domain.playerscore;
+
+public class InvalidWinScoreThresholdException extends RuntimeException {
+
+    public InvalidWinScoreThresholdException(int winScoreThreshold) {
+        super("Win score threshold must be positive: " + winScoreThreshold);
+    }
+}

--- a/src/main/java/io/github/temporalrift/game/scoring/domain/playerscore/PlayerScore.java
+++ b/src/main/java/io/github/temporalrift/game/scoring/domain/playerscore/PlayerScore.java
@@ -6,15 +6,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
-import io.github.temporalrift.events.scoring.ScoresUpdated;
-import io.github.temporalrift.events.session.WinConditionMet;
 import io.github.temporalrift.events.shared.Faction;
-import io.github.temporalrift.game.shared.AggregateRoot;
 
-public class PlayerScore extends AggregateRoot {
+public class PlayerScore {
 
     public static final String AGGREGATE_TYPE = "PlayerScore";
-    public static final String SCORE_THRESHOLD_WIN_TYPE = "SCORE_THRESHOLD";
 
     private final UUID id;
     private final UUID gameId;
@@ -22,43 +18,28 @@ public class PlayerScore extends AggregateRoot {
     private final Faction faction;
     private final List<ScoreEntry> history;
     private int totalScore;
-    private boolean winningScoreRecorded;
 
     public PlayerScore(UUID id, UUID gameId, UUID playerId, Faction faction) {
-        this(id, gameId, playerId, faction, 0, List.of(), false);
+        this(id, gameId, playerId, faction, 0, List.of());
     }
 
     private PlayerScore(
-            UUID id,
-            UUID gameId,
-            UUID playerId,
-            Faction faction,
-            int totalScore,
-            List<ScoreEntry> history,
-            boolean winningScoreRecorded) {
+            UUID id, UUID gameId, UUID playerId, Faction faction, int totalScore, List<ScoreEntry> history) {
         this.id = Objects.requireNonNull(id, "id must not be null");
         this.gameId = Objects.requireNonNull(gameId, "gameId must not be null");
         this.playerId = Objects.requireNonNull(playerId, "playerId must not be null");
         this.faction = Objects.requireNonNull(faction, "faction must not be null");
         this.totalScore = totalScore;
         this.history = new ArrayList<>(Objects.requireNonNull(history, "history must not be null"));
-        this.winningScoreRecorded = winningScoreRecorded;
     }
 
     public static PlayerScore reconstitute(
-            UUID id,
-            UUID gameId,
-            UUID playerId,
-            Faction faction,
-            int totalScore,
-            boolean winningScoreRecorded,
-            List<ScoreEntry> history) {
-        return new PlayerScore(id, gameId, playerId, faction, totalScore, history, winningScoreRecorded);
+            UUID id, UUID gameId, UUID playerId, Faction faction, int totalScore, List<ScoreEntry> history) {
+        return new PlayerScore(id, gameId, playerId, faction, totalScore, history);
     }
 
-    public ScoreEntry apply(int eraNumber, ScoreReason reason, int winScoreThreshold) {
+    public ScoreEntry apply(int eraNumber, ScoreReason reason) {
         validateEra(eraNumber);
-        validateWinScoreThreshold(winScoreThreshold);
         Objects.requireNonNull(reason, "reason must not be null");
         if (!reason.belongsTo(faction)) {
             throw new InvalidScoreReasonException(faction, reason);
@@ -67,8 +48,6 @@ public class PlayerScore extends AggregateRoot {
         totalScore += reason.pointsDelta();
         var entry = new ScoreEntry(eraNumber, reason, reason.pointsDelta(), totalScore);
         history.add(entry);
-        registerScoresUpdated(eraNumber, entry);
-        registerWinConditionIfReached(winScoreThreshold);
         return entry;
     }
 
@@ -76,26 +55,6 @@ public class PlayerScore extends AggregateRoot {
         if (eraNumber < 1) {
             throw new InvalidScoreEraException(eraNumber);
         }
-    }
-
-    private void validateWinScoreThreshold(int winScoreThreshold) {
-        if (winScoreThreshold < 1) {
-            throw new InvalidWinScoreThresholdException(winScoreThreshold);
-        }
-    }
-
-    private void registerScoresUpdated(int eraNumber, ScoreEntry entry) {
-        var update = new ScoresUpdated.ScoreUpdate(
-                playerId, faction, entry.pointsDelta(), entry.reason().name(), totalScore);
-        registerEvent(new ScoresUpdated(gameId, eraNumber, List.of(update)));
-    }
-
-    private void registerWinConditionIfReached(int winScoreThreshold) {
-        if (winningScoreRecorded || totalScore < winScoreThreshold) {
-            return;
-        }
-        winningScoreRecorded = true;
-        registerEvent(new WinConditionMet(gameId, playerId, faction.name(), totalScore, SCORE_THRESHOLD_WIN_TYPE));
     }
 
     public UUID id() {
@@ -116,10 +75,6 @@ public class PlayerScore extends AggregateRoot {
 
     public int totalScore() {
         return totalScore;
-    }
-
-    public boolean winConditionRecorded() {
-        return winningScoreRecorded;
     }
 
     public List<ScoreEntry> history() {

--- a/src/main/java/io/github/temporalrift/game/scoring/domain/playerscore/PlayerScore.java
+++ b/src/main/java/io/github/temporalrift/game/scoring/domain/playerscore/PlayerScore.java
@@ -1,0 +1,128 @@
+package io.github.temporalrift.game.scoring.domain.playerscore;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+import io.github.temporalrift.events.scoring.ScoresUpdated;
+import io.github.temporalrift.events.session.WinConditionMet;
+import io.github.temporalrift.events.shared.Faction;
+import io.github.temporalrift.game.shared.AggregateRoot;
+
+public class PlayerScore extends AggregateRoot {
+
+    public static final String AGGREGATE_TYPE = "PlayerScore";
+    public static final String SCORE_THRESHOLD_WIN_TYPE = "SCORE_THRESHOLD";
+
+    private final UUID id;
+    private final UUID gameId;
+    private final UUID playerId;
+    private final Faction faction;
+    private final List<ScoreEntry> history;
+    private int totalScore;
+    private boolean winningScoreRecorded;
+
+    public PlayerScore(UUID id, UUID gameId, UUID playerId, Faction faction) {
+        this(id, gameId, playerId, faction, 0, List.of(), false);
+    }
+
+    private PlayerScore(
+            UUID id,
+            UUID gameId,
+            UUID playerId,
+            Faction faction,
+            int totalScore,
+            List<ScoreEntry> history,
+            boolean winningScoreRecorded) {
+        this.id = Objects.requireNonNull(id, "id must not be null");
+        this.gameId = Objects.requireNonNull(gameId, "gameId must not be null");
+        this.playerId = Objects.requireNonNull(playerId, "playerId must not be null");
+        this.faction = Objects.requireNonNull(faction, "faction must not be null");
+        this.totalScore = totalScore;
+        this.history = new ArrayList<>(Objects.requireNonNull(history, "history must not be null"));
+        this.winningScoreRecorded = winningScoreRecorded;
+    }
+
+    public static PlayerScore reconstitute(
+            UUID id,
+            UUID gameId,
+            UUID playerId,
+            Faction faction,
+            int totalScore,
+            boolean winningScoreRecorded,
+            List<ScoreEntry> history) {
+        return new PlayerScore(id, gameId, playerId, faction, totalScore, history, winningScoreRecorded);
+    }
+
+    public ScoreEntry apply(int eraNumber, ScoreReason reason, int winScoreThreshold) {
+        validateEra(eraNumber);
+        validateWinScoreThreshold(winScoreThreshold);
+        Objects.requireNonNull(reason, "reason must not be null");
+        if (!reason.belongsTo(faction)) {
+            throw new InvalidScoreReasonException(faction, reason);
+        }
+
+        totalScore += reason.pointsDelta();
+        var entry = new ScoreEntry(eraNumber, reason, reason.pointsDelta(), totalScore);
+        history.add(entry);
+        registerScoresUpdated(eraNumber, entry);
+        registerWinConditionIfReached(winScoreThreshold);
+        return entry;
+    }
+
+    private void validateEra(int eraNumber) {
+        if (eraNumber < 1) {
+            throw new InvalidScoreEraException(eraNumber);
+        }
+    }
+
+    private void validateWinScoreThreshold(int winScoreThreshold) {
+        if (winScoreThreshold < 1) {
+            throw new InvalidWinScoreThresholdException(winScoreThreshold);
+        }
+    }
+
+    private void registerScoresUpdated(int eraNumber, ScoreEntry entry) {
+        var update = new ScoresUpdated.ScoreUpdate(
+                playerId, faction, entry.pointsDelta(), entry.reason().name(), totalScore);
+        registerEvent(new ScoresUpdated(gameId, eraNumber, List.of(update)));
+    }
+
+    private void registerWinConditionIfReached(int winScoreThreshold) {
+        if (winningScoreRecorded || totalScore < winScoreThreshold) {
+            return;
+        }
+        winningScoreRecorded = true;
+        registerEvent(new WinConditionMet(gameId, playerId, faction.name(), totalScore, SCORE_THRESHOLD_WIN_TYPE));
+    }
+
+    public UUID id() {
+        return id;
+    }
+
+    public UUID gameId() {
+        return gameId;
+    }
+
+    public UUID playerId() {
+        return playerId;
+    }
+
+    public Faction faction() {
+        return faction;
+    }
+
+    public int totalScore() {
+        return totalScore;
+    }
+
+    public boolean winConditionRecorded() {
+        return winningScoreRecorded;
+    }
+
+    public List<ScoreEntry> history() {
+        return Collections.unmodifiableList(history);
+    }
+}

--- a/src/main/java/io/github/temporalrift/game/scoring/domain/playerscore/ScoreEntry.java
+++ b/src/main/java/io/github/temporalrift/game/scoring/domain/playerscore/ScoreEntry.java
@@ -1,0 +1,13 @@
+package io.github.temporalrift.game.scoring.domain.playerscore;
+
+import java.util.Objects;
+
+public record ScoreEntry(int eraNumber, ScoreReason reason, int pointsDelta, int newTotal) {
+
+    public ScoreEntry {
+        if (eraNumber < 1) {
+            throw new InvalidScoreEraException(eraNumber);
+        }
+        Objects.requireNonNull(reason, "reason must not be null");
+    }
+}

--- a/src/main/java/io/github/temporalrift/game/scoring/domain/playerscore/ScoreReason.java
+++ b/src/main/java/io/github/temporalrift/game/scoring/domain/playerscore/ScoreReason.java
@@ -1,0 +1,41 @@
+package io.github.temporalrift.game.scoring.domain.playerscore;
+
+import io.github.temporalrift.events.shared.Faction;
+
+public enum ScoreReason {
+    ANNIHILATED_OUTCOME(Faction.ERASERS, 3),
+    CORRUPTED_OPPONENT_CARD(Faction.ERASERS, 2),
+    ERA_ENDED_WITH_FEWER_OUTCOMES(Faction.ERASERS, 5),
+    EVENT_RESOLVED_AS_WRITTEN(Faction.PROPHETS, 4),
+    FULFILLMENT_SUCCEEDED(Faction.PROPHETS, 8),
+    EVENT_RESOLVED_DIFFERENTLY_THAN_WRITTEN(Faction.PROPHETS, -2),
+    SECRET_OUTCOME_WON(Faction.REVISIONISTS, 4),
+    FACTION_UNIDENTIFIED(Faction.REVISIONISTS, 6),
+    MIMIC_CONTRIBUTED_TO_WIN(Faction.REVISIONISTS, 2),
+    CHAIN_LINK_ADDED(Faction.WEAVERS, 2),
+    CHAIN_COMPLETED(Faction.WEAVERS, 10),
+    CHAIN_BROKEN(Faction.WEAVERS, -3),
+    DECLARED_OUTCOME_WON_WITH_RALLY(Faction.ACTIVISTS, 8),
+    DECLARED_OUTCOME_WON(Faction.ACTIVISTS, 4),
+    EXPOSE_CHANGED_PLAYER_BEHAVIOR(Faction.ACTIVISTS, 2);
+
+    private final Faction faction;
+    private final int pointsDelta;
+
+    ScoreReason(Faction faction, int pointsDelta) {
+        this.faction = faction;
+        this.pointsDelta = pointsDelta;
+    }
+
+    public Faction faction() {
+        return faction;
+    }
+
+    public int pointsDelta() {
+        return pointsDelta;
+    }
+
+    boolean belongsTo(Faction playerFaction) {
+        return faction == playerFaction;
+    }
+}

--- a/src/test/java/io/github/temporalrift/game/scoring/domain/playerscore/PlayerScoreTest.java
+++ b/src/test/java/io/github/temporalrift/game/scoring/domain/playerscore/PlayerScoreTest.java
@@ -130,6 +130,13 @@ class PlayerScoreTest {
     }
 
     @Test
+    @DisplayName("score entry rejects non-positive era numbers")
+    void scoreEntryRejectsNonPositiveEra() {
+        assertThatExceptionOfType(InvalidScoreEraException.class)
+                .isThrownBy(() -> new ScoreEntry(0, ScoreReason.DECLARED_OUTCOME_WON, 4, 4));
+    }
+
+    @Test
     @DisplayName("history is immutable to callers")
     void historyIsImmutable() {
         var score = new PlayerScore(UUID.randomUUID(), GAME_ID, PLAYER_ID, Faction.ACTIVISTS);

--- a/src/test/java/io/github/temporalrift/game/scoring/domain/playerscore/PlayerScoreTest.java
+++ b/src/test/java/io/github/temporalrift/game/scoring/domain/playerscore/PlayerScoreTest.java
@@ -122,6 +122,14 @@ class PlayerScoreTest {
     }
 
     @Test
+    @DisplayName("score entry rejects missing reason")
+    void scoreEntryRejectsMissingReason() {
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> new ScoreEntry(ERA, null, 4, 4))
+                .withMessage("reason must not be null");
+    }
+
+    @Test
     @DisplayName("history is immutable to callers")
     void historyIsImmutable() {
         var score = new PlayerScore(UUID.randomUUID(), GAME_ID, PLAYER_ID, Faction.ACTIVISTS);

--- a/src/test/java/io/github/temporalrift/game/scoring/domain/playerscore/PlayerScoreTest.java
+++ b/src/test/java/io/github/temporalrift/game/scoring/domain/playerscore/PlayerScoreTest.java
@@ -13,8 +13,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import io.github.temporalrift.events.scoring.ScoresUpdated;
-import io.github.temporalrift.events.session.WinConditionMet;
 import io.github.temporalrift.events.shared.Faction;
 
 @DisplayName("PlayerScore")
@@ -23,7 +21,6 @@ class PlayerScoreTest {
     static final UUID GAME_ID = UUID.randomUUID();
     static final UUID PLAYER_ID = UUID.randomUUID();
     static final int ERA = 1;
-    static final int WIN_SCORE_THRESHOLD = 20;
 
     static Stream<Arguments> scoringRules() {
         return Stream.of(
@@ -45,27 +42,24 @@ class PlayerScoreTest {
     }
 
     @Test
-    @DisplayName("new score starts at zero without domain events")
+    @DisplayName("new score starts at zero")
     void newScoreStartsAtZero() {
         var score = new PlayerScore(UUID.randomUUID(), GAME_ID, PLAYER_ID, Faction.ERASERS);
 
         assertThat(score.totalScore()).isZero();
         assertThat(score.history()).isEmpty();
-        assertThat(score.winConditionRecorded()).isFalse();
-        assertThat(score.pullEvents()).isEmpty();
     }
 
     @Test
-    @DisplayName("reconstitute restores state without registering events")
-    void reconstituteRegistersNoEvents() {
+    @DisplayName("reconstitute restores persisted state")
+    void reconstituteRestoresState() {
         var entry = new ScoreEntry(ERA, ScoreReason.CHAIN_COMPLETED, 10, 18);
 
-        var score = PlayerScore.reconstitute(
-                UUID.randomUUID(), GAME_ID, PLAYER_ID, Faction.WEAVERS, 18, false, List.of(entry));
+        var score =
+                PlayerScore.reconstitute(UUID.randomUUID(), GAME_ID, PLAYER_ID, Faction.WEAVERS, 18, List.of(entry));
 
         assertThat(score.totalScore()).isEqualTo(18);
         assertThat(score.history()).containsExactly(entry);
-        assertThat(score.pullEvents()).isEmpty();
     }
 
     @ParameterizedTest(name = "{0} {1} scores {2}")
@@ -74,7 +68,7 @@ class PlayerScoreTest {
     void appliesDocumentedScoringRules(Faction faction, ScoreReason reason, int pointsDelta) {
         var score = new PlayerScore(UUID.randomUUID(), GAME_ID, PLAYER_ID, faction);
 
-        var entry = score.apply(ERA, reason, WIN_SCORE_THRESHOLD);
+        var entry = score.apply(ERA, reason);
 
         assertThat(entry.pointsDelta()).isEqualTo(pointsDelta);
         assertThat(entry.newTotal()).isEqualTo(pointsDelta);
@@ -83,37 +77,15 @@ class PlayerScoreTest {
     }
 
     @Test
-    @DisplayName("apply registers ScoresUpdated with score update details")
-    void applyRegistersScoresUpdated() {
-        var score = new PlayerScore(UUID.randomUUID(), GAME_ID, PLAYER_ID, Faction.PROPHETS);
-
-        score.apply(ERA, ScoreReason.EVENT_RESOLVED_AS_WRITTEN, WIN_SCORE_THRESHOLD);
-
-        var events = score.pullEvents();
-        assertThat(events).singleElement().isInstanceOf(ScoresUpdated.class);
-        var event = (ScoresUpdated) events.getFirst();
-        assertThat(event.gameId()).isEqualTo(GAME_ID);
-        assertThat(event.eraNumber()).isEqualTo(ERA);
-        assertThat(event.updates()).singleElement().satisfies(update -> {
-            assertThat(update.playerId()).isEqualTo(PLAYER_ID);
-            assertThat(update.faction()).isEqualTo(Faction.PROPHETS);
-            assertThat(update.pointsDelta()).isEqualTo(4);
-            assertThat(update.reason()).isEqualTo("EVENT_RESOLVED_AS_WRITTEN");
-            assertThat(update.newTotal()).isEqualTo(4);
-        });
-    }
-
-    @Test
     @DisplayName("apply rejects a reason that belongs to another faction")
     void applyRejectsReasonForWrongFaction() {
         var score = new PlayerScore(UUID.randomUUID(), GAME_ID, PLAYER_ID, Faction.ERASERS);
 
         assertThatExceptionOfType(InvalidScoreReasonException.class)
-                .isThrownBy(() -> score.apply(ERA, ScoreReason.EVENT_RESOLVED_AS_WRITTEN, WIN_SCORE_THRESHOLD));
+                .isThrownBy(() -> score.apply(ERA, ScoreReason.EVENT_RESOLVED_AS_WRITTEN));
 
         assertThat(score.totalScore()).isZero();
         assertThat(score.history()).isEmpty();
-        assertThat(score.pullEvents()).isEmpty();
     }
 
     @Test
@@ -121,9 +93,23 @@ class PlayerScoreTest {
     void applyAllowsNegativeAdjustments() {
         var score = new PlayerScore(UUID.randomUUID(), GAME_ID, PLAYER_ID, Faction.WEAVERS);
 
-        score.apply(ERA, ScoreReason.CHAIN_BROKEN, WIN_SCORE_THRESHOLD);
+        score.apply(ERA, ScoreReason.CHAIN_BROKEN);
 
         assertThat(score.totalScore()).isEqualTo(-3);
+    }
+
+    @Test
+    @DisplayName("apply accumulates score and history entries")
+    void applyAccumulatesScoreAndHistory() {
+        var score = new PlayerScore(UUID.randomUUID(), GAME_ID, PLAYER_ID, Faction.ERASERS);
+
+        var first = score.apply(ERA, ScoreReason.ANNIHILATED_OUTCOME);
+        var second = score.apply(ERA, ScoreReason.CORRUPTED_OPPONENT_CARD);
+
+        assertThat(score.totalScore()).isEqualTo(5);
+        assertThat(first.newTotal()).isEqualTo(3);
+        assertThat(second.newTotal()).isEqualTo(5);
+        assertThat(score.history()).containsExactly(first, second);
     }
 
     @Test
@@ -132,53 +118,17 @@ class PlayerScoreTest {
         var score = new PlayerScore(UUID.randomUUID(), GAME_ID, PLAYER_ID, Faction.ACTIVISTS);
 
         assertThatExceptionOfType(InvalidScoreEraException.class)
-                .isThrownBy(() -> score.apply(0, ScoreReason.DECLARED_OUTCOME_WON, WIN_SCORE_THRESHOLD));
-    }
-
-    @Test
-    @DisplayName("apply rejects non-positive win score thresholds")
-    void applyRejectsNonPositiveWinScoreThreshold() {
-        var score = new PlayerScore(UUID.randomUUID(), GAME_ID, PLAYER_ID, Faction.ACTIVISTS);
-
-        assertThatExceptionOfType(InvalidWinScoreThresholdException.class)
-                .isThrownBy(() -> score.apply(ERA, ScoreReason.DECLARED_OUTCOME_WON, 0));
-    }
-
-    @Test
-    @DisplayName("crossing the winning threshold registers WinConditionMet once")
-    void crossingWinningThresholdRegistersWinConditionMetOnce() {
-        var score = PlayerScore.reconstitute(
-                UUID.randomUUID(),
-                GAME_ID,
-                PLAYER_ID,
-                Faction.WEAVERS,
-                18,
-                false,
-                List.of(new ScoreEntry(ERA, ScoreReason.CHAIN_LINK_ADDED, 2, 18)));
-
-        score.apply(2, ScoreReason.CHAIN_LINK_ADDED, WIN_SCORE_THRESHOLD);
-        var firstEvents = score.pullEvents();
-        score.apply(3, ScoreReason.CHAIN_LINK_ADDED, WIN_SCORE_THRESHOLD);
-        var secondEvents = score.pullEvents();
-
-        assertThat(firstEvents).hasSize(2);
-        assertThat(firstEvents.get(1)).isInstanceOfSatisfying(WinConditionMet.class, event -> {
-            assertThat(event.gameId()).isEqualTo(GAME_ID);
-            assertThat(event.winnerId()).isEqualTo(PLAYER_ID);
-            assertThat(event.faction()).isEqualTo("WEAVERS");
-            assertThat(event.finalScore()).isEqualTo(20);
-            assertThat(event.winType()).isEqualTo("SCORE_THRESHOLD");
-        });
-        assertThat(secondEvents).singleElement().isInstanceOf(ScoresUpdated.class);
+                .isThrownBy(() -> score.apply(0, ScoreReason.DECLARED_OUTCOME_WON));
     }
 
     @Test
     @DisplayName("history is immutable to callers")
     void historyIsImmutable() {
         var score = new PlayerScore(UUID.randomUUID(), GAME_ID, PLAYER_ID, Faction.ACTIVISTS);
-        score.apply(ERA, ScoreReason.DECLARED_OUTCOME_WON, WIN_SCORE_THRESHOLD);
+        score.apply(ERA, ScoreReason.DECLARED_OUTCOME_WON);
+        var history = score.history();
+        var entry = new ScoreEntry(ERA, ScoreReason.DECLARED_OUTCOME_WON, 4, 8);
 
-        assertThatExceptionOfType(UnsupportedOperationException.class)
-                .isThrownBy(() -> score.history().add(new ScoreEntry(ERA, ScoreReason.DECLARED_OUTCOME_WON, 4, 8)));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> history.add(entry));
     }
 }

--- a/src/test/java/io/github/temporalrift/game/scoring/domain/playerscore/PlayerScoreTest.java
+++ b/src/test/java/io/github/temporalrift/game/scoring/domain/playerscore/PlayerScoreTest.java
@@ -1,0 +1,184 @@
+package io.github.temporalrift.game.scoring.domain.playerscore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.github.temporalrift.events.scoring.ScoresUpdated;
+import io.github.temporalrift.events.session.WinConditionMet;
+import io.github.temporalrift.events.shared.Faction;
+
+@DisplayName("PlayerScore")
+class PlayerScoreTest {
+
+    static final UUID GAME_ID = UUID.randomUUID();
+    static final UUID PLAYER_ID = UUID.randomUUID();
+    static final int ERA = 1;
+    static final int WIN_SCORE_THRESHOLD = 20;
+
+    static Stream<Arguments> scoringRules() {
+        return Stream.of(
+                Arguments.of(Faction.ERASERS, ScoreReason.ANNIHILATED_OUTCOME, 3),
+                Arguments.of(Faction.ERASERS, ScoreReason.CORRUPTED_OPPONENT_CARD, 2),
+                Arguments.of(Faction.ERASERS, ScoreReason.ERA_ENDED_WITH_FEWER_OUTCOMES, 5),
+                Arguments.of(Faction.PROPHETS, ScoreReason.EVENT_RESOLVED_AS_WRITTEN, 4),
+                Arguments.of(Faction.PROPHETS, ScoreReason.FULFILLMENT_SUCCEEDED, 8),
+                Arguments.of(Faction.PROPHETS, ScoreReason.EVENT_RESOLVED_DIFFERENTLY_THAN_WRITTEN, -2),
+                Arguments.of(Faction.REVISIONISTS, ScoreReason.SECRET_OUTCOME_WON, 4),
+                Arguments.of(Faction.REVISIONISTS, ScoreReason.FACTION_UNIDENTIFIED, 6),
+                Arguments.of(Faction.REVISIONISTS, ScoreReason.MIMIC_CONTRIBUTED_TO_WIN, 2),
+                Arguments.of(Faction.WEAVERS, ScoreReason.CHAIN_LINK_ADDED, 2),
+                Arguments.of(Faction.WEAVERS, ScoreReason.CHAIN_COMPLETED, 10),
+                Arguments.of(Faction.WEAVERS, ScoreReason.CHAIN_BROKEN, -3),
+                Arguments.of(Faction.ACTIVISTS, ScoreReason.DECLARED_OUTCOME_WON_WITH_RALLY, 8),
+                Arguments.of(Faction.ACTIVISTS, ScoreReason.DECLARED_OUTCOME_WON, 4),
+                Arguments.of(Faction.ACTIVISTS, ScoreReason.EXPOSE_CHANGED_PLAYER_BEHAVIOR, 2));
+    }
+
+    @Test
+    @DisplayName("new score starts at zero without domain events")
+    void newScoreStartsAtZero() {
+        var score = new PlayerScore(UUID.randomUUID(), GAME_ID, PLAYER_ID, Faction.ERASERS);
+
+        assertThat(score.totalScore()).isZero();
+        assertThat(score.history()).isEmpty();
+        assertThat(score.winConditionRecorded()).isFalse();
+        assertThat(score.pullEvents()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("reconstitute restores state without registering events")
+    void reconstituteRegistersNoEvents() {
+        var entry = new ScoreEntry(ERA, ScoreReason.CHAIN_COMPLETED, 10, 18);
+
+        var score = PlayerScore.reconstitute(
+                UUID.randomUUID(), GAME_ID, PLAYER_ID, Faction.WEAVERS, 18, false, List.of(entry));
+
+        assertThat(score.totalScore()).isEqualTo(18);
+        assertThat(score.history()).containsExactly(entry);
+        assertThat(score.pullEvents()).isEmpty();
+    }
+
+    @ParameterizedTest(name = "{0} {1} scores {2}")
+    @MethodSource("scoringRules")
+    @DisplayName("applies documented faction scoring rule values")
+    void appliesDocumentedScoringRules(Faction faction, ScoreReason reason, int pointsDelta) {
+        var score = new PlayerScore(UUID.randomUUID(), GAME_ID, PLAYER_ID, faction);
+
+        var entry = score.apply(ERA, reason, WIN_SCORE_THRESHOLD);
+
+        assertThat(entry.pointsDelta()).isEqualTo(pointsDelta);
+        assertThat(entry.newTotal()).isEqualTo(pointsDelta);
+        assertThat(score.totalScore()).isEqualTo(pointsDelta);
+        assertThat(score.history()).containsExactly(entry);
+    }
+
+    @Test
+    @DisplayName("apply registers ScoresUpdated with score update details")
+    void applyRegistersScoresUpdated() {
+        var score = new PlayerScore(UUID.randomUUID(), GAME_ID, PLAYER_ID, Faction.PROPHETS);
+
+        score.apply(ERA, ScoreReason.EVENT_RESOLVED_AS_WRITTEN, WIN_SCORE_THRESHOLD);
+
+        var events = score.pullEvents();
+        assertThat(events).singleElement().isInstanceOf(ScoresUpdated.class);
+        var event = (ScoresUpdated) events.getFirst();
+        assertThat(event.gameId()).isEqualTo(GAME_ID);
+        assertThat(event.eraNumber()).isEqualTo(ERA);
+        assertThat(event.updates()).singleElement().satisfies(update -> {
+            assertThat(update.playerId()).isEqualTo(PLAYER_ID);
+            assertThat(update.faction()).isEqualTo(Faction.PROPHETS);
+            assertThat(update.pointsDelta()).isEqualTo(4);
+            assertThat(update.reason()).isEqualTo("EVENT_RESOLVED_AS_WRITTEN");
+            assertThat(update.newTotal()).isEqualTo(4);
+        });
+    }
+
+    @Test
+    @DisplayName("apply rejects a reason that belongs to another faction")
+    void applyRejectsReasonForWrongFaction() {
+        var score = new PlayerScore(UUID.randomUUID(), GAME_ID, PLAYER_ID, Faction.ERASERS);
+
+        assertThatExceptionOfType(InvalidScoreReasonException.class)
+                .isThrownBy(() -> score.apply(ERA, ScoreReason.EVENT_RESOLVED_AS_WRITTEN, WIN_SCORE_THRESHOLD));
+
+        assertThat(score.totalScore()).isZero();
+        assertThat(score.history()).isEmpty();
+        assertThat(score.pullEvents()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("apply allows negative scoring adjustments")
+    void applyAllowsNegativeAdjustments() {
+        var score = new PlayerScore(UUID.randomUUID(), GAME_ID, PLAYER_ID, Faction.WEAVERS);
+
+        score.apply(ERA, ScoreReason.CHAIN_BROKEN, WIN_SCORE_THRESHOLD);
+
+        assertThat(score.totalScore()).isEqualTo(-3);
+    }
+
+    @Test
+    @DisplayName("apply rejects non-positive era numbers")
+    void applyRejectsNonPositiveEra() {
+        var score = new PlayerScore(UUID.randomUUID(), GAME_ID, PLAYER_ID, Faction.ACTIVISTS);
+
+        assertThatExceptionOfType(InvalidScoreEraException.class)
+                .isThrownBy(() -> score.apply(0, ScoreReason.DECLARED_OUTCOME_WON, WIN_SCORE_THRESHOLD));
+    }
+
+    @Test
+    @DisplayName("apply rejects non-positive win score thresholds")
+    void applyRejectsNonPositiveWinScoreThreshold() {
+        var score = new PlayerScore(UUID.randomUUID(), GAME_ID, PLAYER_ID, Faction.ACTIVISTS);
+
+        assertThatExceptionOfType(InvalidWinScoreThresholdException.class)
+                .isThrownBy(() -> score.apply(ERA, ScoreReason.DECLARED_OUTCOME_WON, 0));
+    }
+
+    @Test
+    @DisplayName("crossing the winning threshold registers WinConditionMet once")
+    void crossingWinningThresholdRegistersWinConditionMetOnce() {
+        var score = PlayerScore.reconstitute(
+                UUID.randomUUID(),
+                GAME_ID,
+                PLAYER_ID,
+                Faction.WEAVERS,
+                18,
+                false,
+                List.of(new ScoreEntry(ERA, ScoreReason.CHAIN_LINK_ADDED, 2, 18)));
+
+        score.apply(2, ScoreReason.CHAIN_LINK_ADDED, WIN_SCORE_THRESHOLD);
+        var firstEvents = score.pullEvents();
+        score.apply(3, ScoreReason.CHAIN_LINK_ADDED, WIN_SCORE_THRESHOLD);
+        var secondEvents = score.pullEvents();
+
+        assertThat(firstEvents).hasSize(2);
+        assertThat(firstEvents.get(1)).isInstanceOfSatisfying(WinConditionMet.class, event -> {
+            assertThat(event.gameId()).isEqualTo(GAME_ID);
+            assertThat(event.winnerId()).isEqualTo(PLAYER_ID);
+            assertThat(event.faction()).isEqualTo("WEAVERS");
+            assertThat(event.finalScore()).isEqualTo(20);
+            assertThat(event.winType()).isEqualTo("SCORE_THRESHOLD");
+        });
+        assertThat(secondEvents).singleElement().isInstanceOf(ScoresUpdated.class);
+    }
+
+    @Test
+    @DisplayName("history is immutable to callers")
+    void historyIsImmutable() {
+        var score = new PlayerScore(UUID.randomUUID(), GAME_ID, PLAYER_ID, Faction.ACTIVISTS);
+        score.apply(ERA, ScoreReason.DECLARED_OUTCOME_WON, WIN_SCORE_THRESHOLD);
+
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+                .isThrownBy(() -> score.history().add(new ScoreEntry(ERA, ScoreReason.DECLARED_OUTCOME_WON, 4, 8)));
+    }
+}


### PR DESCRIPTION
## Summary
- Add the PlayerScore domain aggregate for scoring state and history
- Add ScoreReason values for the documented faction scoring table
- Keep ScoresUpdated and WinConditionMet out of PlayerScore so score publication remains an era-level orchestration concern
- Cover scoring rules, validation, cumulative score history, negative adjustments, and immutable history with domain tests

## Verification
- mvn spotless:apply compile: passed
- mvn test -Dtest=PlayerScoreTest: passed, 22 tests
- PR checks: format-check, build-test-analyze, security-snyk, and SonarCloud Code Analysis are green